### PR TITLE
ボーン情報の外部送信機能の追加

### DIFF
--- a/Assets/ExternalSender/ExternalSender.cs
+++ b/Assets/ExternalSender/ExternalSender.cs
@@ -1,0 +1,50 @@
+﻿//gpsnmeajp
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class ExternalSender : MonoBehaviour {
+    uOSC.uOscClient uClient;
+    GameObject CurrentModel;
+    ControlWPFWindow window;
+   
+
+    // Use this for initialization
+    void Start () {
+        uClient = GetComponent<uOSC.uOscClient>();
+        window = GameObject.Find("ControlWPFWindow").GetComponent<ControlWPFWindow>();
+    }
+	
+	// Update is called once per frame
+	void Update () {
+
+        Animator animator = null;
+
+        CurrentModel = window.GetCurrentModel();
+        if (CurrentModel != null)
+        {
+            animator = CurrentModel.GetComponent<Animator>();
+        }
+
+        if (animator != null)
+        {
+            foreach (HumanBodyBones bone in Enum.GetValues(typeof(HumanBodyBones)))
+            {
+                var Transform = animator.GetBoneTransform(bone);
+                if (Transform != null)
+                {
+                    uClient.Send("/VMC/ExternalSender/Bone/Transform", bone.ToString(), Transform.localPosition.x, Transform.localPosition.y, Transform.localPosition.z, Transform.localRotation.x, Transform.localRotation.y, Transform.localRotation.z, Transform.localRotation.w);
+                }
+            }
+            uClient.Send("/VMC/ExternalSender/Available", 1);
+            uClient.Send("/VMC/ExternalSender/Time", Time.time);
+        }
+        else
+        {
+            uClient.Send("/VMC/ExternalSender/Available", 0);
+            uClient.Send("/VMC/ExternalSender/Time", Time.time);
+        }
+    }
+}
+

--- a/Assets/Scripts/ControlWPFWindow.cs
+++ b/Assets/Scripts/ControlWPFWindow.cs
@@ -2738,4 +2738,10 @@ public class ControlWPFWindow : MonoBehaviour
             isWindowDragging = false;
         }
     }
+
+    //---ExternalSender
+    public GameObject GetCurrentModel()
+    {
+        return CurrentModel;
+    }
 }


### PR DESCRIPTION
OSCを使って現在アクティブなモデルのHumanoid Bone Transformを外部送信するものです。
動作にはuOSCが必要です。
https://github.com/hecomi/uOSC
動作中は常に外部に送信しようとするので適切に有効化・無効化してください。

私の記述部分のLICENCEはプロジェクトのLICENCEと同一とします。

配置は以下のようになります。(簡単のためプルリクエストには含めていません)
![image](https://user-images.githubusercontent.com/33391403/66700437-1ef10780-ed2b-11e9-84fa-6ab13c8b07c0.png)
