### PR TITLE
ボーン情報の外部送信機能のroot位置送信、Blendsharp送信、プロトコル変更、負荷軽減

### DIFF
--- a/Assets/ExternalSender/ExternalSender.cs
+++ b/Assets/ExternalSender/ExternalSender.cs
@@ -3,48 +3,69 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using RootMotion.FinalIK;
 
 public class ExternalSender : MonoBehaviour {
-    uOSC.uOscClient uClient;
-    GameObject CurrentModel;
-    ControlWPFWindow window;
-   
+    uOSC.uOscClient uClient = null;
+    GameObject CurrentModel = null;
+    ControlWPFWindow window = null;
+    Animator animator = null;
+    VRIK vrik = null;
 
-    // Use this for initialization
     void Start () {
         uClient = GetComponent<uOSC.uOscClient>();
         window = GameObject.Find("ControlWPFWindow").GetComponent<ControlWPFWindow>();
+
+        window.ModelLoadedAction += (GameObject CurrentModel) =>
+        {
+            this.CurrentModel = CurrentModel;
+            animator = CurrentModel.GetComponent<Animator>();
+            vrik = CurrentModel.GetComponent<VRIK>();
+        };
     }
-	
+
 	// Update is called once per frame
 	void Update () {
-
-        Animator animator = null;
-
-        CurrentModel = window.GetCurrentModel();
-        if (CurrentModel != null)
+        if (CurrentModel != null && animator != null && uClient != null)
         {
-            animator = CurrentModel.GetComponent<Animator>();
-        }
+            //Root
+            if (vrik == null)
+            {
+                vrik = CurrentModel.GetComponent<VRIK>();
+                Debug.Log("ExternalSender: VRIK Updated");
+            }
 
-        if (animator != null)
-        {
+            if (vrik != null)
+            {
+                var RootTransform = vrik.references.root;
+                if (RootTransform != null)
+                {
+                    uClient.Send("/VMC/ExternalSender/Root/Transform",
+                        "root",
+                        RootTransform.position.x, RootTransform.position.y, RootTransform.position.z,
+                        RootTransform.rotation.x, RootTransform.rotation.y, RootTransform.rotation.z, RootTransform.rotation.w);
+                }
+            }
+
+            //Bones
             foreach (HumanBodyBones bone in Enum.GetValues(typeof(HumanBodyBones)))
             {
                 var Transform = animator.GetBoneTransform(bone);
                 if (Transform != null)
                 {
-                    uClient.Send("/VMC/ExternalSender/Bone/Transform", bone.ToString(), Transform.localPosition.x, Transform.localPosition.y, Transform.localPosition.z, Transform.localRotation.x, Transform.localRotation.y, Transform.localRotation.z, Transform.localRotation.w);
+                    uClient.Send("/VMC/ExternalSender/Bone/Transform", 
+                        bone.ToString(), 
+                        Transform.localPosition.x, Transform.localPosition.y, Transform.localPosition.z, 
+                        Transform.localRotation.x, Transform.localRotation.y, Transform.localRotation.z, Transform.localRotation.w);
                 }
             }
             uClient.Send("/VMC/ExternalSender/Available", 1);
-            uClient.Send("/VMC/ExternalSender/Time", Time.time);
         }
         else
         {
             uClient.Send("/VMC/ExternalSender/Available", 0);
-            uClient.Send("/VMC/ExternalSender/Time", Time.time);
         }
+        uClient.Send("/VMC/ExternalSender/Time", Time.time);
     }
 }
 

--- a/Assets/Scripts/ControlWPFWindow.cs
+++ b/Assets/Scripts/ControlWPFWindow.cs
@@ -2738,10 +2738,4 @@ public class ControlWPFWindow : MonoBehaviour
             isWindowDragging = false;
         }
     }
-
-    //---ExternalSender
-    public GameObject GetCurrentModel()
-    {
-        return CurrentModel;
-    }
 }


### PR DESCRIPTION
前回のPull Requestの追加・修正版です。
https://github.com/sh-akira/VirtualMotionCapture/pull/12

root位置を送信するようになり、6点トラッキング時に中心位置で足踏みするような動きから、ルームスケールでの動きができるようになりました。
Blendsharp送信し、リップシンクや表情が連動するようになりました。
アドレスを短縮してわずかながら通信負荷を軽減しました。
毎フレームGetComponentをしていた問題を修正しました。
ControlWPFWindow.csへの変更を取り消し、ModelLoadedActionを使用するようにしました。
RequireComponentを追加しました。
