### PR TITLE
MIDI CC対応

### DIFF
--- a/Assets/ExternalSender/ExternalSender.cs
+++ b/Assets/ExternalSender/ExternalSender.cs
@@ -133,7 +133,7 @@ public class ExternalSender : MonoBehaviour
                 //Debug.Log("Ext: KeyDown");
                 try
                 {
-                    uClient?.Send("/VMC/Ext/Midi", 1, (int)channel, note);
+                    uClient?.Send("/VMC/Ext/Midi/Note", 1, (int)channel, note);
                 }
                 catch (Exception ex)
                 {
@@ -148,7 +148,22 @@ public class ExternalSender : MonoBehaviour
                 //Debug.Log("Ext: KeyDown");
                 try
                 {
-                    uClient?.Send("/VMC/Ext/Midi", 0, (int)channel, note);
+                    uClient?.Send("/VMC/Ext/Midi/Note", 0, (int)channel, note);
+                }
+                catch (Exception ex)
+                {
+                    Debug.LogError(ex);
+                }
+            }
+        };
+        MidiJack.MidiMaster.knobDelegate += (MidiJack.MidiChannel channel, int knobNo, float value) =>
+        {
+            if (this.isActiveAndEnabled)
+            {
+                //Debug.Log("Ext: KeyDown");
+                try
+                {
+                    uClient?.Send("/VMC/Ext/Midi/CC", 1, (int)channel, knobNo,value);
                 }
                 catch (Exception ex)
                 {

--- a/Assets/Scripts/ControlWPFWindow.cs
+++ b/Assets/Scripts/ControlWPFWindow.cs
@@ -132,6 +132,8 @@ public class ControlWPFWindow : MonoBehaviour
 
         MidiJack.MidiMaster.noteOnDelegate += async (channel, note, velocity) =>
         {
+            Debug.Log("MidiNoteOn:" + channel + "/" + note + "/" + velocity);
+
             var config = new KeyConfig();
             config.type = KeyTypes.Keyboard;
             config.actionType = KeyActionTypes.Face;
@@ -144,6 +146,8 @@ public class ControlWPFWindow : MonoBehaviour
 
         MidiJack.MidiMaster.noteOffDelegate += async (channel, note) =>
         {
+            Debug.Log("MidiNoteOff:" + channel + "/" + note);
+
             var config = new KeyConfig();
             config.type = KeyTypes.Keyboard;
             config.actionType = KeyActionTypes.Face;
@@ -152,6 +156,28 @@ public class ControlWPFWindow : MonoBehaviour
             config.keyName = MidiName(channel, note);
             if (doKeyConfig || doKeySend) { }//  await server.SendCommandAsync(new PipeCommands.KeyUp { Config = config });
             if (!doKeyConfig) CheckKey(config, false);
+        };
+        MidiJack.MidiMaster.knobDelegate += async (MidiJack.MidiChannel channel, int knobNo, float value) =>
+        {
+            Debug.Log("MidiCC:" + channel + "/" + knobNo + "/" + value);
+
+            var config = new KeyConfig();
+            config.type = KeyTypes.Keyboard;
+            config.actionType = KeyActionTypes.Face;
+            config.keyCode = (int)channel;
+            config.keyIndex = knobNo;
+            config.keyName = MidiName(channel, knobNo);
+
+            //あくまで簡易的なチェック。本当は前回のboolとかを配列で用意して、変化したときのみ送信すべき
+            if (value > 0.5f)
+            {
+                if (doKeyConfig || doKeySend) await server.SendCommandAsync(new PipeCommands.KeyDown { Config = config });
+                if (!doKeyConfig) CheckKey(config, true);
+            }
+            else {
+                if (doKeyConfig || doKeySend) { }//  await server.SendCommandAsync(new PipeCommands.KeyUp { Config = config });
+                if (!doKeyConfig) CheckKey(config, false);
+            }
         };
     }
 


### PR DESCRIPTION
ExternalSenderをMIDI CCに対応させ、Note送信時のAddressを変更しました。
ControlWPFWindowをCCに対応させ、解析支援のログを追加しました。
注意: あくまでCC受信機能のみ対応です。
キーコードなどはそのままにしてあり、ショートカットキー設定画面で不安定な挙動をすることを確認しています。