### PR TITLE
通信のフレーム分周とMidiCCWarpperの追加

### DIFF
--- a/Assets/ExternalSender/ExternalSender.cs
+++ b/Assets/ExternalSender/ExternalSender.cs
@@ -19,6 +19,7 @@ public class ExternalSender : MonoBehaviour
     Camera currentCamera = null;
 
     public SteamVR2Input steamVR2Input;
+    public MidiCCWarpper midiCCWarpper;
 
     //フレーム周期
     public int periodStatus = 1;
@@ -140,7 +141,7 @@ public class ExternalSender : MonoBehaviour
             }
         };
 
-        MidiJack.MidiMaster.noteOnDelegate += (MidiJack.MidiChannel channel, int note, float velocity) =>
+        midiCCWarpper.noteOnDelegateProxy += (MidiJack.MidiChannel channel, int note, float velocity) =>
         {
             if (this.isActiveAndEnabled)
             {
@@ -155,7 +156,7 @@ public class ExternalSender : MonoBehaviour
                 }
             }
         };
-        MidiJack.MidiMaster.noteOffDelegate += (MidiJack.MidiChannel channel, int note) =>
+        midiCCWarpper.noteOffDelegateProxy += (MidiJack.MidiChannel channel, int note) =>
         {
             if (this.isActiveAndEnabled)
             {
@@ -170,14 +171,29 @@ public class ExternalSender : MonoBehaviour
                 }
             }
         };
-        MidiJack.MidiMaster.knobDelegate += (MidiJack.MidiChannel channel, int knobNo, float value) =>
+        midiCCWarpper.knobUpdateFloatDelegate += (int knobNo, float value) =>
         {
             if (this.isActiveAndEnabled)
             {
                 //Debug.Log("Ext: KeyDown");
                 try
                 {
-                    uClient?.Send("/VMC/Ext/Midi/CC", 1, (int)channel, knobNo,value);
+                    uClient?.Send("/VMC/Ext/Midi/CC/Val", 1, knobNo, value);
+                }
+                catch (Exception ex)
+                {
+                    Debug.LogError(ex);
+                }
+            }
+        };
+        midiCCWarpper.knobUpdateBoolDelegate += (int knobNo, bool value) =>
+        {
+            if (this.isActiveAndEnabled)
+            {
+                //Debug.Log("Ext: KeyDown");
+                try
+                {
+                    uClient?.Send("/VMC/Ext/Midi/CC/Bit", 1, knobNo, (int)(value?1:0));
                 }
                 catch (Exception ex)
                 {

--- a/Assets/ExternalSender/MidiCCWarpper.cs
+++ b/Assets/ExternalSender/MidiCCWarpper.cs
@@ -1,0 +1,106 @@
+﻿//gpsnmeajp
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.Events;
+
+public class MidiCCWarpper : MonoBehaviour {
+    const int KNOBS = 128;
+    const float Threshold = 0.5f;
+
+    //デリゲート反応用
+    public bool CCAnyUpdate = false;
+    public float[] CCValue = new float[KNOBS];
+    public bool[] CCUpdateBit = new bool[KNOBS];
+
+    //フレーム内処理用
+    public bool[] CCBoolValueInFrame = new bool[KNOBS];
+
+    //MIDIJack集約用プロキシ
+    public Action<MidiJack.MidiChannel, int, float> noteOnDelegateProxy = null;
+    public Action<MidiJack.MidiChannel, int> noteOffDelegateProxy = null;
+    public Action<MidiJack.MidiChannel, int, float> knobDelegateProxy = null;
+
+    //フレーム単位で処理するデリゲート
+    public Action<int, float> knobUpdateFloatDelegate = null;
+    public Action<int, bool> knobUpdateBoolDelegate = null;
+
+    void Start () {
+        MidiJack.MidiMaster.noteOnDelegate += (MidiJack.MidiChannel channel, int note, float velocity) =>
+        {
+            if (noteOnDelegateProxy != null) {
+                noteOnDelegateProxy.Invoke(channel, note, velocity);
+            }
+        };
+        MidiJack.MidiMaster.noteOffDelegate += (MidiJack.MidiChannel channel, int note) => {
+            if (noteOffDelegateProxy != null) {
+                noteOffDelegateProxy.Invoke(channel, note);
+            }
+        };
+
+        MidiJack.MidiMaster.knobDelegate += (MidiJack.MidiChannel channel, int knobNo, float value) =>
+        {
+            if (knobDelegateProxy != null) {
+                knobDelegateProxy.Invoke(channel, knobNo, value);
+            }
+
+            //範囲内かチェック
+            if (0 <= knobNo && knobNo < KNOBS)
+            {
+                //値を記録する
+                CCValue[knobNo] = value;
+                CCUpdateBit[knobNo] = true;
+                CCAnyUpdate = true;
+            }
+        };
+    }
+
+    void Update () {
+        //どれかでも更新があったら
+        if (CCAnyUpdate) {
+            CCAnyUpdate = false;
+
+            //全要素走査
+            for (int i = 0; i < KNOBS; i++)
+            {
+                //更新があったら、通知する
+                if (CCUpdateBit[i])
+                {
+                    CCUpdateBit[i] = false;
+
+                    //値を直接通知する
+                    if (knobUpdateFloatDelegate != null) {
+                        knobUpdateFloatDelegate.Invoke(i, CCValue[i]);
+                    }
+
+                    //--------
+
+                    //しきい値チェック
+
+                    //しきい値以上、かつ直前がfalseなら
+                    if ((CCValue[i] >= Threshold) && (CCBoolValueInFrame[i] == false))
+                    {
+                        //trueにして通知
+                        CCBoolValueInFrame[i] = true;
+                        if (knobUpdateBoolDelegate != null) {
+                            knobUpdateBoolDelegate.Invoke(i, true);
+                        }
+                    }
+
+                    //しきい値以下、かつ直前がtrueなら
+                    if ((CCValue[i] < Threshold) && (CCBoolValueInFrame[i] == true))
+                    {
+                        //falseにして通知
+                        CCBoolValueInFrame[i] = false;
+                        if (knobUpdateBoolDelegate != null)
+                        {
+                            knobUpdateBoolDelegate.Invoke(i, false);
+                        }
+                    }
+
+                }
+            }
+        }
+    }
+}

--- a/Assets/Scripts/ControlWPFWindow.cs
+++ b/Assets/Scripts/ControlWPFWindow.cs
@@ -91,6 +91,8 @@ public class ControlWPFWindow : MonoBehaviour
     public Action<PipeCommands.SetEyeTracking_ViveProEyeOffsets> SetEyeTracking_ViveProEyeOffsetsAction = null;
     public Action<PipeCommands.SetEyeTracking_ViveProEyeUseEyelidMovements> SetEyeTracking_ViveProEyeUseEyelidMovementsAction = null;
 
+    public MidiCCWarpper midiCCWarpper;
+
     // Use this for initialization
     void Start()
     {
@@ -130,7 +132,7 @@ public class ControlWPFWindow : MonoBehaviour
 
         externalMotionSender = ExternalMotionSenderObject.GetComponent<ExternalSender>();
 
-        MidiJack.MidiMaster.noteOnDelegate += async (channel, note, velocity) =>
+        midiCCWarpper.noteOnDelegateProxy += async (channel, note, velocity) =>
         {
             Debug.Log("MidiNoteOn:" + channel + "/" + note + "/" + velocity);
 
@@ -144,7 +146,7 @@ public class ControlWPFWindow : MonoBehaviour
             if (!doKeyConfig) CheckKey(config, true);
         };
 
-        MidiJack.MidiMaster.noteOffDelegate += async (channel, note) =>
+        midiCCWarpper.noteOffDelegateProxy += async (channel, note) =>
         {
             Debug.Log("MidiNoteOff:" + channel + "/" + note);
 
@@ -157,8 +159,9 @@ public class ControlWPFWindow : MonoBehaviour
             if (doKeyConfig || doKeySend) { }//  await server.SendCommandAsync(new PipeCommands.KeyUp { Config = config });
             if (!doKeyConfig) CheckKey(config, false);
         };
-        MidiJack.MidiMaster.knobDelegate += async (MidiJack.MidiChannel channel, int knobNo, float value) =>
+        midiCCWarpper.knobUpdateBoolDelegate += async (int knobNo, bool value) =>
         {
+            MidiJack.MidiChannel channel = MidiJack.MidiChannel.Ch1; //仮でCh1
             Debug.Log("MidiCC:" + channel + "/" + knobNo + "/" + value);
 
             var config = new KeyConfig();
@@ -168,16 +171,14 @@ public class ControlWPFWindow : MonoBehaviour
             config.keyIndex = knobNo;
             config.keyName = MidiName(channel, knobNo);
 
-            //あくまで簡易的なチェック。本当は前回のboolとかを配列で用意して、変化したときのみ送信すべき
-            if (value > 0.5f)
+            if (value)
             {
                 if (doKeyConfig || doKeySend) await server.SendCommandAsync(new PipeCommands.KeyDown { Config = config });
-                if (!doKeyConfig) CheckKey(config, true);
             }
             else {
                 if (doKeyConfig || doKeySend) { }//  await server.SendCommandAsync(new PipeCommands.KeyUp { Config = config });
-                if (!doKeyConfig) CheckKey(config, false);
             }
+            if (!doKeyConfig) CheckKey(config, value);
         };
     }
 


### PR DESCRIPTION
・通信のフレーム分周
毎フレーム送らなくていい情報を選んで送信頻度落とせるようにしました。
適当にUIを追加していただければ幸いです。

・MidiCCWarpperの追加
MIDIJackとの間に入って、中継してフレーム単位にまで頻度落とす&変化点のみを検出してboolで吐くラッパーを挟んでみました。
OSCの通信頻度削減と、キーボード遅延問題の両方に対応できていると思います。
新しいGameObjectを作成してMidiCCWarpperをアタッチし、ExternalSenderとControlWPFWindowの受け口に割り当ててください。

あわせて、ControlWPFWindowのCCの受け取りのChannelは0固定になっています。

※MidiCCWarpperのInspectorの表示は全部デバッグ表示用で、操作しても意味はありません。
　必要に応じてPrivateにしてください。

![image](https://user-images.githubusercontent.com/33391403/67411157-21d7dc00-f5f8-11e9-81f3-0a181b530fda.png)
![image](https://user-images.githubusercontent.com/33391403/67411178-2bf9da80-f5f8-11e9-9ae2-f050d923e453.png)
![image](https://user-images.githubusercontent.com/33391403/67411204-374d0600-f5f8-11e9-9165-ee18c0470229.png)
![image](https://user-images.githubusercontent.com/33391403/67411222-3ddb7d80-f5f8-11e9-8484-9b7e745b0d11.png)
