### PR TITLE
Updated navigation link to the English site.

### DIFF
--- a/docs/_data/navigation.yml
+++ b/docs/_data/navigation.yml
@@ -14,8 +14,8 @@
   link: /about.html
   new_window: false
   highlight: false
-- name: 日本語
-  link: https://sh-akira.github.io/VirtualMotionCapture/
+- name: EN
+  link: https://sh-akira.github.io/VirtualMotionCapture-en/
   new_window: false
   highlight: false
 - name: 한국어


### PR DESCRIPTION
Replaced the Japanese link, which just links back to its own site with the English site link.  Please merge when the English site is ready.