### PR TITLE
腰飛び防止機能、トラッカー情報送信の不足の修正

### DIFF
--- a/Assets/ExternalPlugins/OVRTracking/Scripts/DeviceInfo.cs
+++ b/Assets/ExternalPlugins/OVRTracking/Scripts/DeviceInfo.cs
@@ -8,6 +8,7 @@ using Valve.VR;
 
 namespace sh_akira.OVRTracking
 {
+    //デバイス情報
     public class DeviceInfo
     {
         const float MAX_CHECK_SECONDS = 60f; //最大カウント時間
@@ -94,6 +95,12 @@ namespace sh_akira.OVRTracking
         //トラッキング正常性を用いた処理
         private void saveAndSwapInvalidTransform()
         {
+            //0を検出したら、過去の値を使う
+            if (transform.pos == Vector3.zero && transform.rot == Quaternion.identity)
+            {
+                transform = lastValidTransform[serialNumber];
+            }
+
             //値保存・スワップ処理(時間を考慮する)
             if (IsTrackingOK())
             {
@@ -118,16 +125,13 @@ namespace sh_akira.OVRTracking
             else
             {
                 //正常ではない場合、
-                if (lastValidTransform.ContainsKey(serialNumber))
-                {
-                    //過去に記録したデータが有るならば、過去のデータに差し替える
-                    Vector3 pos = lastValidTransform[serialNumber].pos;
+                //過去に記録したデータが有るならば、過去のデータに差し替える
+                Vector3 pos = lastValidTransform[serialNumber].pos;
 
-                    //回転情報は部分的に反映する(飛びの影響を受けづらいのと、不自然さ防止)
-                    Quaternion rot = Quaternion.Lerp(lastValidTransform[serialNumber].rot, transform.rot, 0.5f);
+                //回転情報は部分的に反映する(飛びの影響を受けづらいのと、不自然さ防止)
+                Quaternion rot = Quaternion.Lerp(lastValidTransform[serialNumber].rot, transform.rot, 0.5f);
 
-                    transform = new SteamVR_Utils.RigidTransform(pos, rot);
-                }
+                transform = new SteamVR_Utils.RigidTransform(pos, rot);
             }
         }
 

--- a/Assets/ExternalPlugins/OVRTracking/Scripts/DeviceInfo.cs
+++ b/Assets/ExternalPlugins/OVRTracking/Scripts/DeviceInfo.cs
@@ -1,0 +1,149 @@
+﻿//gpsnmeajp
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Text;
+using UnityEngine;
+using Valve.VR;
+
+namespace sh_akira.OVRTracking
+{
+    public class DeviceInfo
+    {
+        const float MAX_CHECK_SECONDS = 60f; //最大カウント時間
+        const float LEAP_SECONDS = 1f; //トラッキング復帰までのなめらか時間
+
+        //最後に正常だった位置情報
+        static Dictionary<string, SteamVR_Utils.RigidTransform> lastValidTransform = new Dictionary<string, SteamVR_Utils.RigidTransform>();
+        //前回の正常性情報
+        static Dictionary<string, bool> lastStatus = new Dictionary<string, bool>();
+        //正常に取得できているフレーム数
+        static Dictionary<string, int> validFrames = new Dictionary<string, int>();
+
+        //デバイス取得の度にnewされるのでデータ保持不可
+
+        public string serialNumber { get; set; }
+        public SteamVR_Utils.RigidTransform transform { get; set; }
+
+        //内部で使用する用のステータス状態
+        private TrackedDevicePose_t trackingStatus;
+
+        public DeviceInfo() { }
+
+        //互換性(仮想デバイス含む)
+        public DeviceInfo(SteamVR_Utils.RigidTransform rigidTransform, string serial)
+        {
+            transform = rigidTransform;
+            serialNumber = serial;
+
+            trackingStatus = new TrackedDevicePose_t();
+            trackingStatus.bDeviceIsConnected = true;
+            trackingStatus.bPoseIsValid = true;
+            trackingStatus.eTrackingResult = ETrackingResult.Running_OK;
+
+            saveAndSwapLastValidTransform();
+        }
+
+        public DeviceInfo(SteamVR_Utils.RigidTransform rigidTransform, string serial, TrackedDevicePose_t result)
+        {
+            transform = rigidTransform;
+            serialNumber = serial;
+            trackingStatus = result;
+
+            saveAndSwapLastValidTransform();
+        }
+
+        //正常かどうかを判断する
+        private bool IsTrackingOK()
+        {
+            return trackingStatus.eTrackingResult == ETrackingResult.Running_OK;
+        }
+
+        //最後に正常だった姿勢を保存する
+        private void saveAndSwapLastValidTransform()
+        {
+            if (serialNumber != null)
+            {
+                //正常性Frameの初期値=0
+                if (!validFrames.ContainsKey(serialNumber))
+                {
+                    validFrames[serialNumber] = 0;
+                }
+                //初期正常値はlost
+                if (!lastStatus.ContainsKey(serialNumber))
+                {
+                    lastStatus[serialNumber] = false;
+                }
+                //初期位置は今の値
+                if (!lastValidTransform.ContainsKey(serialNumber))
+                {
+                    lastValidTransform[serialNumber] = transform;
+                }
+
+                //OK時間を算出
+                float okTime = (float)validFrames[serialNumber] / (float)Application.targetFrameRate;
+
+                //正常性情報のログ出力
+                if (lastStatus[serialNumber] != IsTrackingOK())
+                {
+                    if (IsTrackingOK())
+                    {
+                        Debug.Log("Tracking Recovering... [" + serialNumber + "] " + okTime + " sec OK");
+                    }
+                    else
+                    {
+                        Debug.Log("Tracking Lost!     [" + serialNumber + "] " + okTime + " sec OK");
+                    }
+                }
+
+                //正常フレーム数測定
+                if (IsTrackingOK())
+                {
+                    //正常フレーム数を加算する(初期値は0)
+                    //チェックする最大時間以下なら加算する(それ以上はオーバーフロー防止のため加算しない)
+                    if (okTime < MAX_CHECK_SECONDS)
+                    {
+                        validFrames[serialNumber]++;
+                    }
+                }
+                else
+                {
+                    //正常ではない場合、
+                    //正常フレーム数は0にする
+                    validFrames[serialNumber] = 0;
+                }
+
+                //値保存・スワップ処理(時間を考慮する)
+                if (IsTrackingOK())
+                {
+                    //正常な時間が十分経ったら現在の値を保存する
+                    if (okTime > LEAP_SECONDS)
+                    {
+                        lastValidTransform[serialNumber] = transform;
+                    }
+                    else {
+                        //復帰してまだ時間が足りない場合、過去の値からゆっくりと戻す
+                        float a = Mathf.Clamp(okTime / LEAP_SECONDS, 0f, 1f);
+                        Vector3 pos = Vector3.Lerp(lastValidTransform[serialNumber].pos, transform.pos, a);
+                        Quaternion rot = Quaternion.Lerp(lastValidTransform[serialNumber].rot,transform.rot, a);
+
+                        transform = new SteamVR_Utils.RigidTransform(pos, rot);
+
+                        //これにより加速度的に戻る & 飛びから復帰してまた飛んだとき対策
+                        lastValidTransform[serialNumber] = transform;
+                    }
+                }
+                else {
+                    //正常ではない場合、
+                    if (lastValidTransform.ContainsKey(serialNumber)) {
+                        //過去に記録したデータが有るならば、過去のデータに差し替える
+                        transform = lastValidTransform[serialNumber];
+                    }
+                    
+                }
+                //過去正常性情報を更新する
+                lastStatus[serialNumber] = IsTrackingOK();
+            }
+        }
+    }
+}

--- a/Assets/ExternalPlugins/OVRTracking/Scripts/DeviceInfoDebugger.cs
+++ b/Assets/ExternalPlugins/OVRTracking/Scripts/DeviceInfoDebugger.cs
@@ -1,0 +1,28 @@
+﻿//gpsnmeajp
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace sh_akira.OVRTracking
+{
+    public class DeviceInfoDebugger : MonoBehaviour
+    {
+        public bool globalEnable = true;
+        public bool hmdEnable = true;
+        public bool controllerEnable = true;
+        public bool trackerEnable = true;
+
+        void Start()
+        {
+
+        }
+
+        void Update()
+        {
+            DeviceInfo.globalEnable = globalEnable;
+            DeviceInfo.hmdEnable = hmdEnable;
+            DeviceInfo.controllerEnable = controllerEnable;
+            DeviceInfo.trackerEnable = trackerEnable;
+        }
+    }
+}

--- a/Assets/ExternalPlugins/OVRTracking/Scripts/OpenVRWrapper.cs
+++ b/Assets/ExternalPlugins/OVRTracking/Scripts/OpenVRWrapper.cs
@@ -64,13 +64,13 @@ namespace sh_akira.OVRTracking
 
         private string[] serialNumbers = null;
 
-        public Dictionary<ETrackedDeviceClass, List<KeyValuePair<SteamVR_Utils.RigidTransform, string>>> GetTrackerPositions()
+        public Dictionary<ETrackedDeviceClass, List<DeviceInfo>> GetTrackerPositions()
         {
-            var positions = new Dictionary<ETrackedDeviceClass, List<KeyValuePair<SteamVR_Utils.RigidTransform, string>>>();
-            positions.Add(ETrackedDeviceClass.HMD, new List<KeyValuePair<SteamVR_Utils.RigidTransform, string>>());
-            positions.Add(ETrackedDeviceClass.Controller, new List<KeyValuePair<SteamVR_Utils.RigidTransform, string>>());
-            positions.Add(ETrackedDeviceClass.GenericTracker, new List<KeyValuePair<SteamVR_Utils.RigidTransform, string>>());
-            positions.Add(ETrackedDeviceClass.TrackingReference, new List<KeyValuePair<SteamVR_Utils.RigidTransform, string>>());
+            var positions = new Dictionary<ETrackedDeviceClass, List<DeviceInfo>>();
+            positions.Add(ETrackedDeviceClass.HMD, new List<DeviceInfo>());
+            positions.Add(ETrackedDeviceClass.Controller, new List<DeviceInfo>());
+            positions.Add(ETrackedDeviceClass.GenericTracker, new List<DeviceInfo>());
+            positions.Add(ETrackedDeviceClass.TrackingReference, new List<DeviceInfo>());
             TrackedDevicePose_t[] allPoses = new TrackedDevicePose_t[OpenVR.k_unMaxTrackedDeviceCount];
             if (serialNumbers == null) serialNumbers = new string[OpenVR.k_unMaxTrackedDeviceCount];
             //TODO: TrackingUniverseStanding??
@@ -86,7 +86,11 @@ namespace sh_akira.OVRTracking
                     {
                         serialNumbers[i] = GetTrackerSerialNumber(i);
                     }
-                    positions[deviceClass].Add(new KeyValuePair<SteamVR_Utils.RigidTransform, string>(new SteamVR_Utils.RigidTransform(pose.mDeviceToAbsoluteTracking), serialNumbers[i]));
+                    positions[deviceClass].Add(new DeviceInfo(new SteamVR_Utils.RigidTransform(pose.mDeviceToAbsoluteTracking), serialNumbers[i], pose));
+                }
+                else {
+                    //接続切れたらシリアル番号キャッシュクリア
+                    serialNumbers[i] = null;
                 }
             }
             return positions;

--- a/Assets/ExternalPlugins/OVRTracking/Scripts/OpenVRWrapper.cs
+++ b/Assets/ExternalPlugins/OVRTracking/Scripts/OpenVRWrapper.cs
@@ -86,7 +86,7 @@ namespace sh_akira.OVRTracking
                     {
                         serialNumbers[i] = GetTrackerSerialNumber(i);
                     }
-                    positions[deviceClass].Add(new DeviceInfo(new SteamVR_Utils.RigidTransform(pose.mDeviceToAbsoluteTracking), serialNumbers[i], pose));
+                    positions[deviceClass].Add(new DeviceInfo(new SteamVR_Utils.RigidTransform(pose.mDeviceToAbsoluteTracking), serialNumbers[i], pose, openVR.GetTrackedDeviceClass(i)));
                 }
                 else {
                     //接続切れたらシリアル番号キャッシュクリア

--- a/Assets/ExternalSender/ExternalSender.cs
+++ b/Assets/ExternalSender/ExternalSender.cs
@@ -311,14 +311,21 @@ public class ExternalSender : MonoBehaviour
                     trackerHandler.HMDObject.name,
                     trackerHandler.HMDObject.transform.position.x, trackerHandler.HMDObject.transform.position.y, trackerHandler.HMDObject.transform.position.z,
                     trackerHandler.HMDObject.transform.rotation.x, trackerHandler.HMDObject.transform.rotation.y, trackerHandler.HMDObject.transform.rotation.z, trackerHandler.HMDObject.transform.rotation.w);
-
-
+            uClient?.Send("/VMC/Ext/Hmd/Pos/Local",
+                    trackerHandler.HMDObject.name,
+                    trackerHandler.HMDObject.transform.localPosition.x, trackerHandler.HMDObject.transform.localPosition.y, trackerHandler.HMDObject.transform.localPosition.z,
+                    trackerHandler.HMDObject.transform.localRotation.x, trackerHandler.HMDObject.transform.localRotation.y, trackerHandler.HMDObject.transform.localRotation.z, trackerHandler.HMDObject.transform.localRotation.w);
+            
             foreach (var c in trackerHandler.Controllers)
             {
                 uClient?.Send("/VMC/Ext/Con/Pos",
                         c.name,
                         c.transform.position.x, c.transform.position.y, c.transform.position.z,
                         c.transform.rotation.x, c.transform.rotation.y, c.transform.rotation.z, c.transform.rotation.w);
+                uClient?.Send("/VMC/Ext/Con/Pos/Local",
+                        c.name,
+                        c.transform.localPosition.x, c.transform.localPosition.y, c.transform.localPosition.z,
+                        c.transform.localRotation.x, c.transform.localRotation.y, c.transform.localRotation.z, c.transform.localRotation.w);
             }
             foreach (var c in trackerHandler.Trackers)
             {
@@ -326,6 +333,10 @@ public class ExternalSender : MonoBehaviour
                         c.name,
                         c.transform.position.x, c.transform.position.y, c.transform.position.z,
                         c.transform.rotation.x, c.transform.rotation.y, c.transform.rotation.z, c.transform.rotation.w);
+                uClient?.Send("/VMC/Ext/Tra/Pos/Local",
+                        c.name,
+                        c.transform.localPosition.x, c.transform.localPosition.y, c.transform.localPosition.z,
+                        c.transform.localRotation.x, c.transform.localRotation.y, c.transform.localRotation.z, c.transform.localRotation.w);
             }
         }
         frameOfDevices++;


### PR DESCRIPTION
・腰飛び防止機能を追加しました。
　デフォルトで全てオンですが、DeviceInfoDebugger.csでオンオフを切り替えられます。
　なお、オフでも原点に吸い込まれる現象だけは対策が入ります。
・通信切れたデバイスのシリアル番号が再読込されない問題を修正しました。
・トラッカー情報送信にスケールがかかったものだけ送られる問題を修正しました。