### PR TITLE
OSC送信機能の拡張

### DIFF
--- a/Assets/ExternalPlugins/OVRTracking/Scripts/DeviceInfo.cs
+++ b/Assets/ExternalPlugins/OVRTracking/Scripts/DeviceInfo.cs
@@ -37,6 +37,12 @@ namespace sh_akira.OVRTracking
         private TrackedDevicePose_t trackingStatus;
         float okTime = 0;
 
+        //記録情報のリセット
+        static void Reset() {
+            lastValidTransform.Clear();
+            lastStatus.Clear();
+            validFrames.Clear();
+        }
 
         public DeviceInfo() { }
 

--- a/Assets/ExternalPlugins/OVRTracking/Scripts/TrackerHandler.cs
+++ b/Assets/ExternalPlugins/OVRTracking/Scripts/TrackerHandler.cs
@@ -24,6 +24,7 @@ namespace sh_akira.OVRTracking
         public List<GameObject> BaseStations = new List<GameObject>();
         public List<GameObject> BaseStationsObject = new List<GameObject>();
         public bool DisableBaseStationRotation = true;
+        public bool ConvertControllerToTracker = false;
 
         public ExternalReceiverForVMC externalReceiver;
 
@@ -60,6 +61,7 @@ namespace sh_akira.OVRTracking
             Dictionary<ETrackedDeviceClass, List<DeviceInfo>> positions;
             if (IsOVRConnected)
             {
+                OpenVRWrapper.Instance.ConvertControllerToTracker = ConvertControllerToTracker;
                 OpenVRWrapper.Instance.PollingVREvents();
                 positions = OpenVRWrapper.Instance.GetTrackerPositions();
             }

--- a/Assets/ExternalSender/ExternalReceiverForVMC.cs
+++ b/Assets/ExternalSender/ExternalReceiverForVMC.cs
@@ -18,6 +18,9 @@ public class ExternalReceiverForVMC : MonoBehaviour {
     public SortedDictionary<string, SteamVR_Utils.RigidTransform> virtualControllerFiltered = new SortedDictionary<string, SteamVR_Utils.RigidTransform>();
     public SortedDictionary<string, SteamVR_Utils.RigidTransform> virtualTrackerFiltered = new SortedDictionary<string, SteamVR_Utils.RigidTransform>();
 
+    public int receivePort = 39540;
+    public string statusString = "";
+
     ControlWPFWindow window = null;
     GameObject CurrentModel = null;
     Camera currentCamera = null;
@@ -216,7 +219,8 @@ public class ExternalReceiverForVMC : MonoBehaviour {
                         lookTargetOSC.name = "lookTargetOSC";
                     }
                     //位置を書き込む
-                    if (lookTargetOSC.transform != null) {
+                    if (lookTargetOSC.transform != null)
+                    {
                         lookTargetOSC.transform.position = pos;
                     }
 
@@ -226,7 +230,8 @@ public class ExternalReceiverForVMC : MonoBehaviour {
                         vrmLookAtHead.Target = lookTargetOSC.transform;
                     }
                 }
-                else {
+                else
+                {
                     //視線を止める
                     if (vrmLookAtHead != null)
                     {
@@ -234,6 +239,17 @@ public class ExternalReceiverForVMC : MonoBehaviour {
                     }
                 }
             }
+            //情報要求 V2.4
+            else if (message.address == "/VMC/Ext/Set/Req")
+            {
+                externalSender.SendPerLowRate(); //即時送信
+            }
+            //情報表示 V2.4
+            else if (message.address == "/VMC/Ext/Set/Res" && (message.values[0] is string))
+            {
+                statusString = (string)message.values[0];
+            }
+
         }
     }
     SteamVR_Utils.RigidTransform SetTransform(ref Vector3 pos, ref Quaternion rot,ref uOSC.Message message) {
@@ -270,6 +286,7 @@ public class ExternalReceiverForVMC : MonoBehaviour {
 
     public void ChangeOSCPort(int port)
     {
+        receivePort = port;
         var uServer = GetComponent<uOSC.uOscServer>();
         uServer.enabled = false;
         var type = typeof(uOSC.uOscServer);

--- a/Assets/ExternalSender/ExternalSender.cs
+++ b/Assets/ExternalSender/ExternalSender.cs
@@ -1,5 +1,6 @@
 ﻿//gpsnmeajp
 using System;
+using System.IO;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
@@ -229,6 +230,16 @@ public class ExternalSender : MonoBehaviour
                 }
             }
         };
+
+
+        if (ControlWPFWindow.CurrentSettings.VRMPath != null)
+        {
+            //有効なVRMが読み込まれているならメタデータを記録する(低頻度送信に頼る)
+            if (File.Exists(ControlWPFWindow.CurrentSettings.VRMPath))
+            {
+                this.vrmdata = window.LoadVRM(ControlWPFWindow.CurrentSettings.VRMPath);
+            }
+        }
     }
     // Update is called once per frame
     void Update()

--- a/Assets/Scripts/ControlWPFWindow.cs
+++ b/Assets/Scripts/ControlWPFWindow.cs
@@ -829,7 +829,7 @@ public class ControlWPFWindow : MonoBehaviour
 
     #region VRM
 
-    private VRMData LoadVRM(string path)
+    public VRMData LoadVRM(string path)
     {
         if (string.IsNullOrEmpty(path))
         {

--- a/Assets/Scripts/ControlWPFWindow.cs
+++ b/Assets/Scripts/ControlWPFWindow.cs
@@ -1671,7 +1671,7 @@ public class ControlWPFWindow : MonoBehaviour
 
     void SetWindowClickThrough(bool enable)
     {
-        CurrentSettings.HideBorder = enable;
+        CurrentSettings.WindowClickThrough = enable;
 #if !UNITY_EDITOR   // エディタ上では動きません。
         var hwnd = GetUnityWindowHandle();
         //var hwnd = GetActiveWindow();
@@ -2823,6 +2823,9 @@ public class ControlWPFWindow : MonoBehaviour
             {
                 await server.SendCommandAsync(new PipeCommands.LoadVRMPath { Path = CurrentSettings.VRMPath });
                 ImportVRM(CurrentSettings.VRMPath, false, CurrentSettings.EnableNormalMapFix, CurrentSettings.DeleteHairNormalMap);
+
+                //メタ情報をOSC送信する
+                VRMmetaLodedAction?.Invoke(LoadVRM(CurrentSettings.VRMPath));
             }
             if (CurrentSettings.BackgroundColor != null)
             {

--- a/Assets/Scripts/ControlWPFWindow.cs
+++ b/Assets/Scripts/ControlWPFWindow.cs
@@ -88,6 +88,8 @@ public class ControlWPFWindow : MonoBehaviour
     public Action<GameObject> ModelLoadedAction = null;
     public Action<GameObject> AdditionalSettingAction = null;
     public Action<Camera> CameraChangedAction = null;
+    public Action<VRMData> VRMmetaLodedAction = null;
+    public Action LightChangedAction = null;
 
     public Action<GameObject> EyeTracking_TobiiCalibrationAction = null;
     public Action<PipeCommands.SetEyeTracking_TobiiOffsets> SetEyeTracking_TobiiOffsetsAction = null;
@@ -291,6 +293,9 @@ public class ControlWPFWindow : MonoBehaviour
             {
                 var d = (PipeCommands.ImportVRM)e.Data;
                 ImportVRM(d.Path, d.ImportForCalibration, d.UseCurrentFixSetting ? CurrentSettings.EnableNormalMapFix : d.EnableNormalMapFix, d.UseCurrentFixSetting ? CurrentSettings.DeleteHairNormalMap : d.DeleteHairNormalMap);
+
+                //メタ情報をOSC送信する
+                VRMmetaLodedAction?.Invoke(LoadVRM(d.Path));
             }
 
             else if (e.CommandType == typeof(PipeCommands.Calibrate))
@@ -804,6 +809,8 @@ public class ControlWPFWindow : MonoBehaviour
             MainDirectionalLightTransform.eulerAngles = new Vector3(x, y, MainDirectionalLightTransform.eulerAngles.z);
             CurrentSettings.LightRotationX = x;
             CurrentSettings.LightRotationY = y;
+
+            LightChangedAction?.Invoke();
         }
     }
 
@@ -813,6 +820,8 @@ public class ControlWPFWindow : MonoBehaviour
         {
             CurrentSettings.LightColor = new Color(r, g, b, a);
             MainDirectionalLight.color = CurrentSettings.LightColor;
+
+            LightChangedAction?.Invoke();
         }
     }
 


### PR DESCRIPTION
一つ前のプルリクエストの内容に加え、
・受信状態/ポート番号
・DirectionalLight位置・色
・VRM基本情報(パスとtitle)
・Option文字列
・背景色
・ウィンドウ属性情報
を送信する機能

・情報送信要求
・Response文字列
を受信する機能を追加しています。

Unity上で必要な変更は以下です
・ExternalReceiverのReceive Portにデフォルト値(39540)を設定する
・ExternalSenderにExternalReceiverを登録する

変更が必要なUIは以下です
・ExternalSenderのOption Stringに書き込むテキストボックスを追加してください。
　これはユーザースクリプトが設定に使用するための汎用的な文字列です。
　デジタルサイネージなど遠隔の装置や、UIを持たない表示装置などを設定・制御することを想定しています。
・ExternalReceiverのStatus Stringを表示するテキストボックスを追加してください。
　これはユーザースクリプトが応答に使用するための汎用的な文字列です。
　デジタルサイネージなど遠隔の装置や、UIを持たない表示装置などからの応答内容を表示することを想定しています。
