### PR TITLE
設定ファイルロード処理の整理と初期ロード、WPFのファイルダイアログ初期パス記憶

### DIFF
--- a/Assets/Scripts/ControlWPFWindow.cs
+++ b/Assets/Scripts/ControlWPFWindow.cs
@@ -2881,18 +2881,12 @@ public class ControlWPFWindow : MonoBehaviour
     public class CommonSettings
     {
         public string LoadSettingFilePathOnStart = ""; //起動時に読み込む設定ファイルパス
-        public string CurrentPathOnSettingFileDialog = ""; //設定ファイルダイアログパス
-        public string CurrentPathOnVRMFileDialog = ""; //VRMファイルダイアログパス
-        public string CurrentPathOnExternalCameraFileDialog = ""; //ExternalCameraダイアログパス
 
         //初期値
         [OnDeserializing()]
         internal void OnDeserializingMethod(StreamingContext context)
         {
             LoadSettingFilePathOnStart = "";
-            CurrentPathOnSettingFileDialog = "";
-            CurrentPathOnVRMFileDialog = "";
-            CurrentPathOnExternalCameraFileDialog = "";
         }
     }
 

--- a/Assets/Scripts/ControlWPFWindow.cs
+++ b/Assets/Scripts/ControlWPFWindow.cs
@@ -716,7 +716,7 @@ public class ControlWPFWindow : MonoBehaviour
                 }
                 else
                 {
-                    //現在の設定を適用する
+                    //現在の設定を再適用する
                     ApplyCurrentSettings();
                 }
             }
@@ -2909,11 +2909,10 @@ public class ControlWPFWindow : MonoBehaviour
             path = Application.dataPath + "/../default.json";
         }
 
-        lastLoadedConfigPath = path; //パスを記録
-
         //設定の読み込みを試みる
         try
         {
+            path = Path.GetFullPath(path); //フルパスに変換
             CurrentSettings = Json.Serializer.Deserialize<Settings>(File.ReadAllText(path)); //設定を読み込み
             float divide = 0;
             //腰情報を読み込む
@@ -2926,12 +2925,22 @@ public class ControlWPFWindow : MonoBehaviour
         {
             //読み込めなかったときはエラーをファイルとして出力
             File.WriteAllText(Application.dataPath + "/../exception.txt", ex.ToString() + ":" + ex.Message);
+            Debug.LogError(ex.ToString() + ":" + ex.Message);
         }
+
+        Debug.Log("Loaded config: " + path);
 
         //スケールを元に戻す
         ResetTrackerScale();
         //設定を適用する
         ApplyCurrentSettings();
+
+        //有効なJSONが取得できたかチェック
+        if (CurrentSettings != null)
+        {
+            lastLoadedConfigPath = path; //パスを記録
+        }
+
         //設定の変更を通知
         LoadedConfigPathChangedAction?.Invoke();
     }

--- a/ControlWindowWPF/ControlWindowWPF/Globals.cs
+++ b/ControlWindowWPF/ControlWindowWPF/Globals.cs
@@ -1,8 +1,11 @@
-﻿using System;
+﻿using sh_akira;
+using System;
+using System.IO;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.Runtime.Serialization;
 using UnityMemoryMappedFile;
 
 namespace VirtualMotionCaptureControlPanel
@@ -59,5 +62,55 @@ namespace VirtualMotionCaptureControlPanel
             }
             return true;
         }
+
+
+        [Serializable]
+        public class CommonSettingsWPF
+        {
+            public string CurrentPathOnSettingFileDialog = ""; //設定ファイルダイアログパス
+            public string CurrentPathOnVRMFileDialog = ""; //VRMファイルダイアログパス
+            public string CurrentPathOnExternalCameraFileDialog = ""; //ExternalCameraダイアログパス
+            public string CurrentPathOnCameraPlusFileDialog = ""; //CameraPlusダイアログパス
+
+            //初期値
+            [OnDeserializing()]
+            internal void OnDeserializingMethod(StreamingContext context)
+            {
+                CurrentPathOnSettingFileDialog = "";
+                CurrentPathOnVRMFileDialog = "";
+                CurrentPathOnExternalCameraFileDialog = "";
+                CurrentPathOnCameraPlusFileDialog = "";
+            }
+        }
+
+        public static CommonSettingsWPF CurrentCommonSettingsWPF = new CommonSettingsWPF();
+
+        //共通設定の書き込み
+        public static void SaveCommonSettings()
+        {
+            string path = Path.GetFullPath(GetCurrentAppDir() + "/../commonWPF.json");
+            File.WriteAllText(path, Json.Serializer.ToReadable(Json.Serializer.Serialize(CurrentCommonSettingsWPF)));
+        }
+
+        //共通設定の読み込み
+        public static void LoadCommonSettings()
+        {
+            string path = Path.GetFullPath(GetCurrentAppDir() + "/../commonWPF.json");
+            if (!File.Exists(path))
+            {
+                return;
+            }
+            try
+            {
+                CurrentCommonSettingsWPF = Json.Serializer.Deserialize<CommonSettingsWPF>(File.ReadAllText(path)); //設定を読み込み
+            }
+            catch (Exception e) {
+                //エラー発生時は初期値にする
+                CurrentCommonSettingsWPF = new CommonSettingsWPF();
+                SaveCommonSettings();
+            }
+        }
+
+
     }
 }

--- a/ControlWindowWPF/ControlWindowWPF/MainWindow.xaml.cs
+++ b/ControlWindowWPF/ControlWindowWPF/MainWindow.xaml.cs
@@ -62,6 +62,7 @@ namespace VirtualMotionCaptureControlPanel
             DefaultFaceComboBox.ItemsSource = DefaultFacesBase;
             LipSyncDeviceComboBox.ItemsSource = LipSyncDevices;
             UpdateWindowTitle();
+            Globals.LoadCommonSettings();
         }
 
         private void UpdateWindowTitle()
@@ -323,21 +324,39 @@ namespace VirtualMotionCaptureControlPanel
 
         private async void LoadSettingsButton_Click(object sender, RoutedEventArgs e)
         {
+            Globals.LoadCommonSettings();
+
             var ofd = new Microsoft.Win32.OpenFileDialog();
             ofd.Filter = "Setting File(*.json)|*.json";
+            ofd.InitialDirectory = Globals.CurrentCommonSettingsWPF.CurrentPathOnSettingFileDialog;
             if (ofd.ShowDialog() == true)
             {
                 await Globals.Client.SendCommandAsync(new PipeCommands.LoadSettings { Path = ofd.FileName });
+
+                if (Globals.CurrentCommonSettingsWPF.CurrentPathOnSettingFileDialog != System.IO.Path.GetDirectoryName(ofd.FileName))
+                {
+                    Globals.CurrentCommonSettingsWPF.CurrentPathOnSettingFileDialog = System.IO.Path.GetDirectoryName(ofd.FileName);
+                    Globals.SaveCommonSettings();
+                }
             }
         }
 
         private async void SaveSettingsButton_Click(object sender, RoutedEventArgs e)
         {
+            Globals.LoadCommonSettings();
+
             var sfd = new Microsoft.Win32.SaveFileDialog();
             sfd.Filter = "Setting File(*.json)|*.json";
+            sfd.InitialDirectory = Globals.CurrentCommonSettingsWPF.CurrentPathOnSettingFileDialog;
             if (sfd.ShowDialog() == true)
             {
                 await Globals.Client.SendCommandAsync(new PipeCommands.SaveSettings { Path = sfd.FileName });
+
+                if (Globals.CurrentCommonSettingsWPF.CurrentPathOnSettingFileDialog != System.IO.Path.GetDirectoryName(sfd.FileName))
+                {
+                    Globals.CurrentCommonSettingsWPF.CurrentPathOnSettingFileDialog = System.IO.Path.GetDirectoryName(sfd.FileName);
+                    Globals.SaveCommonSettings();
+                }
             }
         }
 

--- a/ControlWindowWPF/ControlWindowWPF/SettingWindow.xaml.cs
+++ b/ControlWindowWPF/ControlWindowWPF/SettingWindow.xaml.cs
@@ -127,9 +127,12 @@ namespace VirtualMotionCaptureControlPanel
                 MessageBox.Show(LanguageSelector.Get("SettingWindow_SelectedItemError"), LanguageSelector.Get("Error"), MessageBoxButton.OK, MessageBoxImage.Error);
                 return;
             }
+            Globals.LoadCommonSettings();
+
             var tracker = ControllerComboBox.SelectedItem as TrackerConfigWindow.TrackerInfo;
             var ofd = new OpenFileDialog();
             ofd.Filter = "externalcamera.cfg|externalcamera.cfg";
+            ofd.InitialDirectory = Globals.CurrentCommonSettingsWPF.CurrentPathOnExternalCameraFileDialog;
             if (ofd.ShowDialog() == true)
             {
                 var configs = new Dictionary<string, string>();
@@ -157,6 +160,12 @@ namespace VirtualMotionCaptureControlPanel
                 var fov = GetFloat("fov");
 
                 await Globals.Client?.SendCommandAsync(new PipeCommands.SetExternalCameraConfig { x = x, y = y, z = z, rx = rx, ry = ry, rz = rz, fov = fov, ControllerName = tracker.SerialNumber });
+
+                if (Globals.CurrentCommonSettingsWPF.CurrentPathOnExternalCameraFileDialog != System.IO.Path.GetDirectoryName(ofd.FileName))
+                {
+                    Globals.CurrentCommonSettingsWPF.CurrentPathOnExternalCameraFileDialog = System.IO.Path.GetDirectoryName(ofd.FileName);
+                    Globals.SaveCommonSettings();
+                }
             }
         }
 
@@ -167,6 +176,8 @@ namespace VirtualMotionCaptureControlPanel
                 MessageBox.Show(LanguageSelector.Get("SettingWindow_SelectedItemError"), LanguageSelector.Get("Error"), MessageBoxButton.OK, MessageBoxImage.Error);
                 return;
             }
+            Globals.LoadCommonSettings();
+
             var tracker = ControllerComboBox.SelectedItem as TrackerConfigWindow.TrackerInfo;
             await Globals.Client?.SendCommandWaitAsync(new PipeCommands.GetExternalCameraConfig { ControllerName = tracker.SerialNumber }, r =>
             {
@@ -177,6 +188,8 @@ namespace VirtualMotionCaptureControlPanel
                     sfd.Filter = "externalcamera.cfg|externalcamera.cfg";
                     sfd.Title = "Export externalcamera.cfg";
                     sfd.FileName = "externalcamera.cfg";
+                    sfd.InitialDirectory = Globals.CurrentCommonSettingsWPF.CurrentPathOnExternalCameraFileDialog;
+
                     if (sfd.ShowDialog() == true)
                     {
                         var culture = System.Globalization.CultureInfo.InvariantCulture;
@@ -194,6 +207,12 @@ namespace VirtualMotionCaptureControlPanel
                         lines.Add($"disableStandardAssets=False");
                         lines.Add($"frameSkip=0");
                         File.WriteAllLines(sfd.FileName, lines);
+
+                        if (Globals.CurrentCommonSettingsWPF.CurrentPathOnExternalCameraFileDialog != System.IO.Path.GetDirectoryName(sfd.FileName))
+                        {
+                            Globals.CurrentCommonSettingsWPF.CurrentPathOnExternalCameraFileDialog = System.IO.Path.GetDirectoryName(sfd.FileName);
+                            Globals.SaveCommonSettings();
+                        }
                     }
                 });
             });
@@ -478,9 +497,12 @@ namespace VirtualMotionCaptureControlPanel
 
         private async void CameraPlus_ImportButton_Click(object sender, RoutedEventArgs e)
         {
+            Globals.LoadCommonSettings();
+
             var ofd = new OpenFileDialog();
 
             ofd.Filter = "cameraplus.cfg|cameraplus.cfg";
+            ofd.InitialDirectory = Globals.CurrentCommonSettingsWPF.CurrentPathOnCameraPlusFileDialog;
             if (ofd.ShowDialog() == true)
             {
                 var configs = new Dictionary<string, string>();
@@ -508,6 +530,11 @@ namespace VirtualMotionCaptureControlPanel
                 var fov = GetFloat("fov");
 
                 await Globals.Client?.SendCommandAsync(new PipeCommands.ImportCameraPlus { x = x, y = y, z = z, rx = rx, ry = ry, rz = rz, fov = fov });
+                if (Globals.CurrentCommonSettingsWPF.CurrentPathOnCameraPlusFileDialog != System.IO.Path.GetDirectoryName(ofd.FileName))
+                {
+                    Globals.CurrentCommonSettingsWPF.CurrentPathOnCameraPlusFileDialog = System.IO.Path.GetDirectoryName(ofd.FileName);
+                    Globals.SaveCommonSettings();
+                }
             }
         }
 
@@ -518,10 +545,13 @@ namespace VirtualMotionCaptureControlPanel
                 var d = (PipeCommands.ReturnExportCameraPlus)r;
                 Dispatcher.Invoke(() =>
                 {
+                    Globals.LoadCommonSettings();
                     var ofd = new OpenFileDialog();
                     ofd.Filter = "cameraplus.cfg|cameraplus.cfg";
                     ofd.Title = "Select cameraplus.cfg";
                     ofd.FileName = "cameraplus.cfg";
+                    ofd.InitialDirectory = Globals.CurrentCommonSettingsWPF.CurrentPathOnCameraPlusFileDialog;
+
                     if (ofd.ShowDialog() == true)
                     {
                         var culture = System.Globalization.CultureInfo.InvariantCulture;
@@ -538,6 +568,12 @@ namespace VirtualMotionCaptureControlPanel
                             if (lines[i].StartsWith("fov")) lines[i] = $"fov=" + d.fov.ToString("G", format);
                         }
                         File.WriteAllLines(ofd.FileName, lines);
+
+                        if (Globals.CurrentCommonSettingsWPF.CurrentPathOnCameraPlusFileDialog != System.IO.Path.GetDirectoryName(ofd.FileName))
+                        {
+                            Globals.CurrentCommonSettingsWPF.CurrentPathOnCameraPlusFileDialog = System.IO.Path.GetDirectoryName(ofd.FileName);
+                            Globals.SaveCommonSettings();
+                        }
                     }
                 });
             });

--- a/ControlWindowWPF/ControlWindowWPF/VRMImportWindow.xaml.cs
+++ b/ControlWindowWPF/ControlWindowWPF/VRMImportWindow.xaml.cs
@@ -34,8 +34,12 @@ namespace VirtualMotionCaptureControlPanel
 
         private async void LoadVRMButton_Click(object sender, RoutedEventArgs e)
         {
+            Globals.LoadCommonSettings();
+
             var ofd = new Microsoft.Win32.OpenFileDialog();
             ofd.Filter = "VRM File(*.vrm)|*.vrm";
+            ofd.InitialDirectory = Globals.CurrentCommonSettingsWPF.CurrentPathOnVRMFileDialog;
+
             if (ofd.ShowDialog() == true)
             {
                 await Globals.Client.SendCommandWaitAsync(new PipeCommands.LoadVRM { Path = ofd.FileName }, d =>
@@ -43,6 +47,11 @@ namespace VirtualMotionCaptureControlPanel
                     var ret = (PipeCommands.ReturnLoadVRM)d;
                     Dispatcher.Invoke(() => LoadMetaData(ret.Data));
                 });
+                if (Globals.CurrentCommonSettingsWPF.CurrentPathOnVRMFileDialog != System.IO.Path.GetDirectoryName(ofd.FileName))
+                {
+                    Globals.CurrentCommonSettingsWPF.CurrentPathOnVRMFileDialog = System.IO.Path.GetDirectoryName(ofd.FileName);
+                    Globals.SaveCommonSettings();
+                }
             }
         }
 


### PR DESCRIPTION
・Unity側の設定ファイル読み込み処理を分割・整理しました
・Unity側の設定ファイル読み込み・書き込み時に「前回読み込んだ設定ファイルパス」として記録するようにしました
・Unity側の起動時に、「前回読み込んだ設定ファイルパス」から自動ロードするようにしました
・共通設定ファイルcommon.jsonを追加

・WPF側の各ファイルダイアログの成功時パスを保存、次回の初期パスとして読み込むようにしました
・共通設定ファイルcommonWPF.jsonを追加

コードの変更のみですが、変更の規模と影響範囲が大きいため詳細なレビューをお願いします。

特に
・common.json, commonWPF.jsonの生成位置が想定通りか
・LoadCommonSettings()の例外処理はこれでよいか
ご確認ください。
