### PR TITLE
WPF: 存在しないパスが前回パスになっているときの例外問題への対処

### DIFF
--- a/ControlWindowWPF/ControlWindowWPF/Globals.cs
+++ b/ControlWindowWPF/ControlWindowWPF/Globals.cs
@@ -85,6 +85,10 @@ namespace VirtualMotionCaptureControlPanel
 
         public static CommonSettingsWPF CurrentCommonSettingsWPF = new CommonSettingsWPF();
 
+        public static string ExistDirectoryOrNull(string path) {
+            return Directory.Exists(path) ? path : null;
+        }
+
         //共通設定の書き込み
         public static void SaveCommonSettings()
         {

--- a/ControlWindowWPF/ControlWindowWPF/MainWindow.xaml.cs
+++ b/ControlWindowWPF/ControlWindowWPF/MainWindow.xaml.cs
@@ -328,7 +328,7 @@ namespace VirtualMotionCaptureControlPanel
 
             var ofd = new Microsoft.Win32.OpenFileDialog();
             ofd.Filter = "Setting File(*.json)|*.json";
-            ofd.InitialDirectory = Globals.CurrentCommonSettingsWPF.CurrentPathOnSettingFileDialog;
+            ofd.InitialDirectory = Globals.ExistDirectoryOrNull(Globals.CurrentCommonSettingsWPF.CurrentPathOnSettingFileDialog);
             if (ofd.ShowDialog() == true)
             {
                 await Globals.Client.SendCommandAsync(new PipeCommands.LoadSettings { Path = ofd.FileName });
@@ -347,7 +347,7 @@ namespace VirtualMotionCaptureControlPanel
 
             var sfd = new Microsoft.Win32.SaveFileDialog();
             sfd.Filter = "Setting File(*.json)|*.json";
-            sfd.InitialDirectory = Globals.CurrentCommonSettingsWPF.CurrentPathOnSettingFileDialog;
+            sfd.InitialDirectory = Globals.ExistDirectoryOrNull(Globals.CurrentCommonSettingsWPF.CurrentPathOnSettingFileDialog);
             if (sfd.ShowDialog() == true)
             {
                 await Globals.Client.SendCommandAsync(new PipeCommands.SaveSettings { Path = sfd.FileName });

--- a/ControlWindowWPF/ControlWindowWPF/SettingWindow.xaml.cs
+++ b/ControlWindowWPF/ControlWindowWPF/SettingWindow.xaml.cs
@@ -132,7 +132,7 @@ namespace VirtualMotionCaptureControlPanel
             var tracker = ControllerComboBox.SelectedItem as TrackerConfigWindow.TrackerInfo;
             var ofd = new OpenFileDialog();
             ofd.Filter = "externalcamera.cfg|externalcamera.cfg";
-            ofd.InitialDirectory = Globals.CurrentCommonSettingsWPF.CurrentPathOnExternalCameraFileDialog;
+            ofd.InitialDirectory = Globals.ExistDirectoryOrNull(Globals.CurrentCommonSettingsWPF.CurrentPathOnExternalCameraFileDialog);
             if (ofd.ShowDialog() == true)
             {
                 var configs = new Dictionary<string, string>();
@@ -188,7 +188,7 @@ namespace VirtualMotionCaptureControlPanel
                     sfd.Filter = "externalcamera.cfg|externalcamera.cfg";
                     sfd.Title = "Export externalcamera.cfg";
                     sfd.FileName = "externalcamera.cfg";
-                    sfd.InitialDirectory = Globals.CurrentCommonSettingsWPF.CurrentPathOnExternalCameraFileDialog;
+                    sfd.InitialDirectory = Globals.ExistDirectoryOrNull(Globals.CurrentCommonSettingsWPF.CurrentPathOnExternalCameraFileDialog);
 
                     if (sfd.ShowDialog() == true)
                     {
@@ -502,7 +502,7 @@ namespace VirtualMotionCaptureControlPanel
             var ofd = new OpenFileDialog();
 
             ofd.Filter = "cameraplus.cfg|cameraplus.cfg";
-            ofd.InitialDirectory = Globals.CurrentCommonSettingsWPF.CurrentPathOnCameraPlusFileDialog;
+            ofd.InitialDirectory = Globals.ExistDirectoryOrNull(Globals.CurrentCommonSettingsWPF.CurrentPathOnCameraPlusFileDialog);
             if (ofd.ShowDialog() == true)
             {
                 var configs = new Dictionary<string, string>();
@@ -550,7 +550,7 @@ namespace VirtualMotionCaptureControlPanel
                     ofd.Filter = "cameraplus.cfg|cameraplus.cfg";
                     ofd.Title = "Select cameraplus.cfg";
                     ofd.FileName = "cameraplus.cfg";
-                    ofd.InitialDirectory = Globals.CurrentCommonSettingsWPF.CurrentPathOnCameraPlusFileDialog;
+                    ofd.InitialDirectory = Globals.ExistDirectoryOrNull(Globals.CurrentCommonSettingsWPF.CurrentPathOnCameraPlusFileDialog);
 
                     if (ofd.ShowDialog() == true)
                     {

--- a/ControlWindowWPF/ControlWindowWPF/VRMImportWindow.xaml.cs
+++ b/ControlWindowWPF/ControlWindowWPF/VRMImportWindow.xaml.cs
@@ -38,7 +38,7 @@ namespace VirtualMotionCaptureControlPanel
 
             var ofd = new Microsoft.Win32.OpenFileDialog();
             ofd.Filter = "VRM File(*.vrm)|*.vrm";
-            ofd.InitialDirectory = Globals.CurrentCommonSettingsWPF.CurrentPathOnVRMFileDialog;
+            ofd.InitialDirectory = Globals.ExistDirectoryOrNull(Globals.CurrentCommonSettingsWPF.CurrentPathOnVRMFileDialog);
 
             if (ofd.ShowDialog() == true)
             {


### PR DESCRIPTION
少々安直ですが、WPFのFileDialog表示時にパスの存在チェックをするようにしました。
これとは別に例外ハンドリングは別途行ったほうが良い気がしています。