### PR TITLE
トラッキング状態に応じたIK Weightの自動操作(既定で無効)とバグ修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,4 @@ sysinfo.txt
 # Builds
 *.apk
 *.unitypackage
+common.json

--- a/Assets/ExternalPlugins/OVRTracking/Scripts/OpenVRWrapper.cs
+++ b/Assets/ExternalPlugins/OVRTracking/Scripts/OpenVRWrapper.cs
@@ -97,7 +97,6 @@ namespace sh_akira.OVRTracking
                     if (trackedHistory[i] == false && pose.bPoseIsValid == false)
                     {
                         //無視する
-                        Debug.Log("" + i + " is Never Tracked");
                         continue;
                     }
                     trackedHistory[i] = true;

--- a/Assets/ExternalPlugins/OVRTracking/Scripts/TrackerHandler.cs
+++ b/Assets/ExternalPlugins/OVRTracking/Scripts/TrackerHandler.cs
@@ -40,6 +40,21 @@ namespace sh_akira.OVRTracking
         // Use this for initialization
         void Start()
         {
+            InitializeTrackingWatcher();
+
+            OpenVRWrapper.Instance.OnOVRConnected += OpenVR_OnOVRConnected;
+            OpenVRWrapper.Instance.Setup();
+        }
+
+        private void OpenVR_OnOVRConnected(object sender, OVRConnectedEventArgs e)
+        {
+            IsOVRConnected = e.Connected;
+        }
+
+        private bool IsOVRConnected = false;
+
+        private void InitializeTrackingWatcher()
+        {
             //Watcherを用意
             HMDObjectTrackingWatcher = HMDObject.AddComponent<TrackingWatcher>();
 
@@ -55,17 +70,21 @@ namespace sh_akira.OVRTracking
             {
                 TrackersObjectTrackingWatcher[i] = TrackersObject[i].AddComponent<TrackingWatcher>();
             }
-
-            OpenVRWrapper.Instance.OnOVRConnected += OpenVR_OnOVRConnected;
-            OpenVRWrapper.Instance.Setup();
         }
 
-        private void OpenVR_OnOVRConnected(object sender, OVRConnectedEventArgs e)
+        //設定を初期化したい時に使う
+        public void ClearTrackingWatcher()
         {
-            IsOVRConnected = e.Connected;
+            HMDObjectTrackingWatcher.Clear();
+            for (int i = 0; i < ControllersObjectTrackingWatcher.Count; i++)
+            {
+                ControllersObjectTrackingWatcher[i].Clear();
+            }
+            for (int i = 0; i < TrackersObjectTrackingWatcher.Count; i++)
+            {
+                TrackersObjectTrackingWatcher[i].Clear();
+            }
         }
-
-        private bool IsOVRConnected = false;
 
         public Transform GetTrackerTransformByName(string name)
         {

--- a/Assets/ExternalPlugins/OVRTracking/Scripts/TrackerHandler.cs
+++ b/Assets/ExternalPlugins/OVRTracking/Scripts/TrackerHandler.cs
@@ -10,16 +10,26 @@ namespace sh_akira.OVRTracking
     public class TrackerHandler : MonoBehaviour
     {
         public GameObject HMDObject;
+        public TrackingWatcher HMDObjectTrackingWatcher;
+
         public List<GameObject> Controllers = new List<GameObject>();
         public List<GameObject> ControllersObject = new List<GameObject>();
+        [System.NonSerialized]
+        public List<TrackingWatcher> ControllersObjectTrackingWatcher = null;
+
         public GameObject CameraControllerObject;
         [System.NonSerialized]
         public ETrackedDeviceClass CameraControllerType = ETrackedDeviceClass.Invalid;
         [System.NonSerialized]
         public string CameraControllerName = null;
+
         [System.NonSerialized]
         public List<GameObject> Trackers = new List<GameObject>();
         public List<GameObject> TrackersObject = new List<GameObject>();
+        [System.NonSerialized]
+        public List<TrackingWatcher> TrackersObjectTrackingWatcher = null;
+
+
         [System.NonSerialized]
         public List<GameObject> BaseStations = new List<GameObject>();
         public List<GameObject> BaseStationsObject = new List<GameObject>();
@@ -30,6 +40,22 @@ namespace sh_akira.OVRTracking
         // Use this for initialization
         void Start()
         {
+            //Watcherを用意
+            HMDObjectTrackingWatcher = HMDObject.AddComponent<TrackingWatcher>();
+
+            //指定サイズでListを生成
+            ControllersObjectTrackingWatcher = new List<TrackingWatcher>(new TrackingWatcher[ControllersObject.Count]);
+            for (int i = 0; i < ControllersObject.Count; i++)
+            {
+                ControllersObjectTrackingWatcher[i] = ControllersObject[i].AddComponent<TrackingWatcher>();
+            }
+
+            TrackersObjectTrackingWatcher = new List<TrackingWatcher>(new TrackingWatcher[TrackersObject.Count]);
+            for (int i = 0; i < TrackersObject.Count; i++)
+            {
+                TrackersObjectTrackingWatcher[i] = TrackersObject[i].AddComponent<TrackingWatcher>();
+            }
+
             OpenVRWrapper.Instance.OnOVRConnected += OpenVR_OnOVRConnected;
             OpenVRWrapper.Instance.Setup();
         }
@@ -90,7 +116,9 @@ namespace sh_akira.OVRTracking
             var hmdPositions = positions[ETrackedDeviceClass.HMD];
             if (hmdPositions.Any())
             {
-                HMDObject.transform.SetPositionAndRotationLocal(hmdPositions.FirstOrDefault());
+                DeviceInfo hmdInfo = hmdPositions.FirstOrDefault();
+                HMDObject.transform.SetPositionAndRotationLocal(hmdInfo);
+                HMDObjectTrackingWatcher.IsOK(hmdInfo.isOK);
             }
 
             var controllerPositions = positions[ETrackedDeviceClass.Controller];
@@ -109,7 +137,10 @@ namespace sh_akira.OVRTracking
                 if (Controllers.Count != controllerPositions.Count) Controllers.Clear();
                 for (int i = 0; i < controllerPositions.Count && i < ControllersObject.Count; i++)
                 {
-                    ControllersObject[i].transform.SetPositionAndRotationLocal(controllerPositions[i]);
+                    DeviceInfo deviceInfo = controllerPositions[i];
+                    ControllersObject[i].transform.SetPositionAndRotationLocal(deviceInfo);
+                    ControllersObjectTrackingWatcher[i].IsOK(deviceInfo.isOK);
+
                     if (Controllers.Contains(ControllersObject[i]) == false) Controllers.Add(ControllersObject[i]);
                 }
             }
@@ -133,7 +164,10 @@ namespace sh_akira.OVRTracking
                 if (Trackers.Count != trackerPositions.Count) Trackers.Clear();
                 for (int i = 0; i < trackerPositions.Count && i < TrackersObject.Count; i++)
                 {
-                    TrackersObject[i].transform.SetPositionAndRotationLocal(trackerPositions[i]);
+                    DeviceInfo deviceInfo = trackerPositions[i];
+                    TrackersObject[i].transform.SetPositionAndRotationLocal(deviceInfo);
+                    TrackersObjectTrackingWatcher[i].IsOK(deviceInfo.isOK);
+
                     if (Trackers.Contains(TrackersObject[i]) == false) Trackers.Add(TrackersObject[i]);
                 }
             }

--- a/Assets/ExternalPlugins/OVRTracking/Scripts/TrackingWatcher.cs
+++ b/Assets/ExternalPlugins/OVRTracking/Scripts/TrackingWatcher.cs
@@ -6,6 +6,7 @@ using UnityEngine;
 public class TrackingWatcher : MonoBehaviour {
 
     public bool ok = false; //デバッグ用
+    public bool action = false;//デバッグ用
 
     Action<float> SetWeightAction = null;
 
@@ -13,11 +14,22 @@ public class TrackingWatcher : MonoBehaviour {
     public void IsOK(bool ok)
     {
         this.ok = ok;
+
+        SetWeightAction?.Invoke(ok?1f:0f);
     }
 
     public void SetActionOfSetWeight(Action<float> action)
     {
         this.SetWeightAction = action;
+        this.action = true;
+    }
+
+    public void Clear()
+    {
+        this.SetWeightAction = null;
+        this.action = false;
+
+        Debug.Log(transform.name + " : Clear!");
     }
 
     /*

--- a/Assets/ExternalPlugins/OVRTracking/Scripts/TrackingWatcher.cs
+++ b/Assets/ExternalPlugins/OVRTracking/Scripts/TrackingWatcher.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class TrackingWatcher : MonoBehaviour {
+
+    public bool ok = false; //デバッグ用
+
+    Action<float> SetWeightAction = null;
+
+    //Tracker Handlerから呼び出される
+    public void IsOK(bool ok)
+    {
+        this.ok = ok;
+    }
+
+    public void SetActionOfSetWeight(Action<float> action)
+    {
+        this.SetWeightAction = action;
+    }
+
+    /*
+	void Start () {
+		
+	}
+	
+	void Update () {
+		
+	}
+    */
+}

--- a/Assets/ExternalPlugins/OVRTracking/Scripts/TrackingWatcher.cs
+++ b/Assets/ExternalPlugins/OVRTracking/Scripts/TrackingWatcher.cs
@@ -4,41 +4,59 @@ using System.Collections.Generic;
 using UnityEngine;
 
 public class TrackingWatcher : MonoBehaviour {
+    const float FallRate = -10f; //Weightを落とす速度
+    const float RecoverRate = 10f; //Weightを復帰させる速度()
+
+    public bool enable = false; //機能を使用するか
 
     public bool ok = false; //デバッグ用
     public bool action = false;//デバッグ用
+    public float weight = 1f;
 
     Action<float> SetWeightAction = null;
 
-    //Tracker Handlerから呼び出される
+    //Tracker Handlerから呼び出される。今トラッキングが正常かどうか
     public void IsOK(bool ok)
     {
         this.ok = ok;
-
-        SetWeightAction?.Invoke(ok?1f:0f);
     }
 
+    //IKをキャリブレーションするときにWeightを設定するためのActionが渡される。
     public void SetActionOfSetWeight(Action<float> action)
     {
         this.SetWeightAction = action;
         this.action = true;
     }
 
+    //キャリブレーション開始時にActionを破棄する
     public void Clear()
     {
         this.SetWeightAction = null;
         this.action = false;
+        weight = 1f;
 
         Debug.Log(transform.name + " : Clear!");
     }
 
-    /*
 	void Start () {
 		
 	}
-	
-	void Update () {
-		
-	}
-    */
+
+    void Update () {
+        //Actionがなければ実行しない
+        if (SetWeightAction == null || !enable) {
+            return;
+        }
+
+        //状態に合わせて重みを変える
+        if (ok)
+        {
+            weight += RecoverRate * Time.deltaTime;
+        }
+        else {
+            weight += FallRate * Time.deltaTime;
+        }
+        weight = Mathf.Clamp01(weight);        
+        SetWeightAction?.Invoke(weight);
+    }
 }

--- a/Assets/ExternalPlugins/OVRTracking/Scripts/TrackingWatcher.cs.meta
+++ b/Assets/ExternalPlugins/OVRTracking/Scripts/TrackingWatcher.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0d16a3d8dafdc744db9d7ee8ed87a436
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/VirtualMotionCapture.unity
+++ b/Assets/Scenes/VirtualMotionCapture.unity
@@ -5813,7 +5813,7 @@ MonoBehaviour:
   - {fileID: 1255601378}
   - {fileID: 1653217471}
   DisableBaseStationRotation: 1
-  externalReceiver: {fileID: 0}
+  externalReceiver: {fileID: 389263779}
 --- !u!4 &1128534204
 Transform:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/VirtualMotionCapture.unity
+++ b/Assets/Scenes/VirtualMotionCapture.unity
@@ -481,7 +481,7 @@ AudioListener:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 137141882}
-  m_Enabled: 1
+  m_Enabled: 0
 --- !u!124 &137141886
 Behaviour:
   m_ObjectHideFlags: 0
@@ -1605,7 +1605,7 @@ AudioListener:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 241859925}
-  m_Enabled: 1
+  m_Enabled: 0
 --- !u!124 &241859929
 Behaviour:
   m_ObjectHideFlags: 0
@@ -1719,7 +1719,7 @@ AudioListener:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 282840810}
-  m_Enabled: 1
+  m_Enabled: 0
 --- !u!114 &282840812
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1987,17 +1987,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c6fd25003140c0e47b39261ea2e0f470, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  MonitorPosition: {fileID: 0}
-  LookTarget: {fileID: 0}
-  StartPos: {x: 0, y: 0, z: 0}
-  ScaleX: 0.5
-  ScaleY: 0.2
-  OffsetX: 0
-  OffsetY: 0
-  CenterX: 0.5
-  CenterY: 0.5
-  Smoothing: 0.7
-  controlWPFWindow: {fileID: 1407685704}
 --- !u!4 &326004793
 Transform:
   m_ObjectHideFlags: 0
@@ -2022,19 +2011,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 1fd512d95b6700d44a5763b8c74b228a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  MonitorPosition: {fileID: 0}
-  LookTarget: {fileID: 0}
-  StartPos: {x: 0, y: 0, z: 0}
-  ScaleX: 0.5
-  ScaleY: 0.2
-  OffsetX: 0
-  OffsetY: 0
-  CenterX: 0.5
-  CenterY: 0.5
-  Smoothing: 0.7
-  controlWPFWindow: {fileID: 1407685704}
-  faceController: {fileID: 69806225}
-  UseEyelidMovements: 1
 --- !u!114 &326004795
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2046,9 +2022,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 47613961cde0a8b4aa4f79219b7e523c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  EnableEye: 1
-  EnableEyeDataCallback: 0
-  EnableEyeVersion: 0
 --- !u!1 &378345255
 GameObject:
   m_ObjectHideFlags: 0
@@ -2714,7 +2687,7 @@ AudioListener:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 462948916}
-  m_Enabled: 1
+  m_Enabled: 0
 --- !u!124 &462948919
 Behaviour:
   m_ObjectHideFlags: 0
@@ -3640,7 +3613,7 @@ AudioListener:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 680324445}
-  m_Enabled: 1
+  m_Enabled: 0
 --- !u!124 &680324448
 Behaviour:
   m_ObjectHideFlags: 0
@@ -5506,6 +5479,42 @@ MeshFilter:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1035641541}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &1044902095
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1044902097}
+  - component: {fileID: 1044902096}
+  m_Layer: 0
+  m_Name: AudioListener
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!81 &1044902096
+AudioListener:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1044902095}
+  m_Enabled: 1
+--- !u!4 &1044902097
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1044902095}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 30
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1049932826
 GameObject:
   m_ObjectHideFlags: 0
@@ -5763,6 +5772,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   HMDObject: {fileID: 131724274}
+  HMDObjectTrackingWatcher: {fileID: 0}
   Controllers: []
   ControllersObject:
   - {fileID: 617002694}
@@ -6730,6 +6740,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   HMDObject: {fileID: 315295892}
+  HMDObjectTrackingWatcher: {fileID: 0}
   Controllers: []
   ControllersObject:
   - {fileID: 655512911}
@@ -6859,7 +6870,7 @@ AudioListener:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1312323650}
-  m_Enabled: 1
+  m_Enabled: 0
 --- !u!124 &1312323653
 Behaviour:
   m_ObjectHideFlags: 0
@@ -7760,7 +7771,7 @@ AudioListener:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1404284878}
-  m_Enabled: 1
+  m_Enabled: 0
 --- !u!124 &1404284881
 Behaviour:
   m_ObjectHideFlags: 0
@@ -10336,8 +10347,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: b2f7a0c5fd055af4083cbe934b512f19, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  controlWPFWindow: {fileID: 1407685704}
-  sdkConfiguration: {fileID: 11400000, guid: dd276808621df4e2380660ade912baf3, type: 2}
 --- !u!4 &1770264196
 Transform:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Calibrator.cs
+++ b/Assets/Scripts/Calibrator.cs
@@ -48,6 +48,11 @@ public class Calibrator
         hmdAdjusterTransform.rotation = ik.references.head.rotation;
         ik.solver.spine.headTarget = hmdAdjusterTransform;
 
+        HMDTransform.GetComponent<TrackingWatcher>().SetActionOfSetWeight((float weight) => {
+//            ik.references.hea = weight;
+
+        });
+
         // Size
         float sizeF = hmdAdjusterTransform.position.y / ik.references.head.position.y;
         ik.references.root.localScale = Vector3.one * sizeF;

--- a/Assets/Scripts/Calibrator.cs
+++ b/Assets/Scripts/Calibrator.cs
@@ -16,6 +16,7 @@ public class Calibrator
     public static Transform pelvisOffsetTransform;
     public static float pelvisOffsetHeight = 0f;
 
+    /*
     /// <summary>
     /// Calibrates VRIK to the specified trackers using the VRIKTrackerCalibrator.Settings.
     /// </summary>
@@ -41,6 +42,9 @@ public class Calibrator
             return;
         }
 
+        //TrackingWatcherを初期化する
+        GameObject.Find("HandTrackerRoot").GetComponent<sh_akira.OVRTracking.TrackerHandler>().ClearTrackingWatcher();
+
         // Head
         Transform hmdAdjusterTransform = ik.solver.spine.headTarget == null ? (new GameObject("hmdAdjuster")).transform : ik.solver.spine.headTarget;
         hmdAdjusterTransform.parent = HMDTransform;
@@ -48,9 +52,10 @@ public class Calibrator
         hmdAdjusterTransform.rotation = ik.references.head.rotation;
         ik.solver.spine.headTarget = hmdAdjusterTransform;
 
+        //TrackingWatcherにWeight設定用アクションを設定
+        Debug.Log("### Set");
         HMDTransform.GetComponent<TrackingWatcher>().SetActionOfSetWeight((float weight) => {
-//            ik.references.hea = weight;
-
+            //Do noting
         });
 
         // Size
@@ -74,6 +79,12 @@ public class Calibrator
             ik.solver.spine.pelvisPositionWeight = 1f;
             ik.solver.spine.pelvisRotationWeight = 1f;
 
+            //TrackingWatcherにWeight設定用アクションを設定
+            PelvisTransform.GetComponentInChildren<TrackingWatcher>().SetActionOfSetWeight((float weight) => {
+                ik.solver.spine.pelvisPositionWeight = weight;
+                ik.solver.spine.pelvisRotationWeight = weight;
+            });
+
             ik.solver.plantFeet = false;
             ik.solver.spine.neckStiffness = 0f;
             ik.solver.spine.maxRootAngle = 180f;
@@ -92,6 +103,14 @@ public class Calibrator
             Vector3 leftHandUp = Vector3.Cross(ik.solver.leftArm.wristToPalmAxis, ik.solver.leftArm.palmToThumbAxis);
             leftHandAdjusterTransform.rotation = QuaTools.MatchRotation(LeftHandTransform.rotation * Quaternion.LookRotation(settings.handTrackerForward, settings.handTrackerUp), settings.handTrackerForward, settings.handTrackerUp, ik.solver.leftArm.wristToPalmAxis, leftHandUp);
             ik.solver.leftArm.target = leftHandAdjusterTransform;
+
+            ik.solver.leftArm.positionWeight = 1f;
+            ik.solver.leftArm.rotationWeight = 1f;
+            //TrackingWatcherにWeight設定用アクションを設定
+            LeftHandTransform.parent.GetComponent<TrackingWatcher>().SetActionOfSetWeight((float weight) => {
+                ik.solver.leftArm.positionWeight = weight;
+                ik.solver.leftArm.rotationWeight = weight;
+            });
         }
         else
         {
@@ -108,6 +127,15 @@ public class Calibrator
             Vector3 rightHandUp = -Vector3.Cross(ik.solver.rightArm.wristToPalmAxis, ik.solver.rightArm.palmToThumbAxis);
             rightHandAdjusterTransform.rotation = QuaTools.MatchRotation(RightHandTransform.rotation * Quaternion.LookRotation(settings.handTrackerForward, settings.handTrackerUp), settings.handTrackerForward, settings.handTrackerUp, ik.solver.rightArm.wristToPalmAxis, rightHandUp);
             ik.solver.rightArm.target = rightHandAdjusterTransform;
+
+            ik.solver.rightArm.positionWeight = 1f;
+            ik.solver.rightArm.rotationWeight = 1f;
+            //TrackingWatcherにWeight設定用アクションを設定
+            RightHandTransform.parent.GetComponent<TrackingWatcher>().SetActionOfSetWeight((float weight) => {
+                ik.solver.rightArm.positionWeight = weight;
+                ik.solver.rightArm.rotationWeight = weight;
+            });
+
         }
         else
         {
@@ -140,7 +168,7 @@ public class Calibrator
         ik.solver.spine.minHeadHeight = 0f;
         ik.solver.locomotion.weight = PelvisTransform == null && LeftFootTransform == null && RightFootTransform == null ? 1f : 0f;
     }
-
+    */
     private static Transform CalibrateLeg(Settings settings, Transform FootTransform, IKSolverVR.Leg leg, Transform lastBone, Vector3 hmdForwardAngle, Vector3 rootForward, bool isLeft)
     {
         Transform footAdjusterTransform = leg.target == null ? new GameObject(isLeft ? "leftFootAdjuster" : "rightFootAdjuster").transform : leg.target;
@@ -169,6 +197,13 @@ public class Calibrator
         leg.positionWeight = 1f;
         leg.rotationWeight = 1f;
 
+        //TrackingWatcherにWeight設定用アクションを設定
+        FootTransform.parent.GetComponent<TrackingWatcher>().SetActionOfSetWeight((float weight) => {
+            leg.positionWeight = weight;
+            leg.rotationWeight = weight;
+        });
+
+
         // Bend goal
 
         Transform bendGoal = leg.bendGoal == null ? (new GameObject(isLeft ? "leftFootBendGoal" : "rightFootBendGoal")).transform : leg.bendGoal;
@@ -179,7 +214,6 @@ public class Calibrator
         //leg.bendGoal = null;
         //leg.bendGoalWeight = 0f;
     }
-
     public static IEnumerator CalibrateScaled(Transform realTrackerRoot, Transform handTrackerRoot, Transform headTrackerRoot, Transform footTrackerRoot, VRIK ik, Settings settings, Vector3 LeftHandOffset, Vector3 RightHandOffset, Transform HMDTransform, Transform PelvisTransform = null, Transform LeftHandTransform = null, Transform RightHandTransform = null, Transform LeftFootTransform = null, Transform RightFootTransform = null, Transform LeftElbowTransform = null, Transform RightElbowTransform = null, Transform LeftKneeTransform = null, Transform RightKneeTransform = null)
     {
         if (!ik.solver.initiated)
@@ -193,6 +227,9 @@ public class Calibrator
             Debug.LogError("Can not calibrate VRIK without the head tracker.");
             yield break;
         }
+
+        //TrackingWatcherを初期化する
+        GameObject.Find("HandTrackerRoot").GetComponent<sh_akira.OVRTracking.TrackerHandler>().ClearTrackingWatcher();
 
         //トラッカーのルートスケールを初期値に戻す
         handTrackerRoot.localScale = new Vector3(1.0f, 1.0f, 1.0f);
@@ -369,6 +406,12 @@ public class Calibrator
         ik.solver.spine.headTarget = hmdAdjusterTransform;
         ik.solver.spine.headClampWeight = 0.38f;
 
+        //TrackingWatcherにWeight設定用アクションを設定
+        HMDTransform.GetComponent<TrackingWatcher>().SetActionOfSetWeight((float weight) => {
+            //Do noting
+        });
+
+
         // Body
         if (PelvisTransform != null)
         {
@@ -379,6 +422,12 @@ public class Calibrator
             ik.solver.spine.pelvisTarget = pelvisAdjusterTransform;
             ik.solver.spine.pelvisPositionWeight = 1f;
             ik.solver.spine.pelvisRotationWeight = 1f;
+
+            //TrackingWatcherにWeight設定用アクションを設定
+            PelvisTransform.GetComponentInChildren<TrackingWatcher>().SetActionOfSetWeight((float weight) => {
+                ik.solver.spine.pelvisPositionWeight = weight;
+                ik.solver.spine.pelvisRotationWeight = weight;
+            });
 
             ik.solver.plantFeet = false;
             ik.solver.spine.neckStiffness = 0f;
@@ -402,6 +451,14 @@ public class Calibrator
             Vector3 leftHandUp = Vector3.Cross(ik.solver.leftArm.wristToPalmAxis, ik.solver.leftArm.palmToThumbAxis);
             leftHandAdjusterTransform.rotation = QuaTools.MatchRotation(LeftHandTransform.rotation * Quaternion.LookRotation(settings.handTrackerForward, settings.handTrackerUp), settings.handTrackerForward, settings.handTrackerUp, ik.solver.leftArm.wristToPalmAxis, leftHandUp);
             ik.solver.leftArm.target = leftHandAdjusterTransform;
+
+            ik.solver.leftArm.positionWeight = 1f;
+            ik.solver.leftArm.rotationWeight = 1f;
+            //TrackingWatcherにWeight設定用アクションを設定
+            LeftHandTransform.parent.GetComponent<TrackingWatcher>().SetActionOfSetWeight((float weight) => {
+                ik.solver.leftArm.positionWeight = weight;
+                ik.solver.leftArm.rotationWeight = weight;
+            });
         }
         else
         {
@@ -418,6 +475,14 @@ public class Calibrator
             Vector3 rightHandUp = -Vector3.Cross(ik.solver.rightArm.wristToPalmAxis, ik.solver.rightArm.palmToThumbAxis);
             rightHandAdjusterTransform.rotation = QuaTools.MatchRotation(RightHandTransform.rotation * Quaternion.LookRotation(settings.handTrackerForward, settings.handTrackerUp), settings.handTrackerForward, settings.handTrackerUp, ik.solver.rightArm.wristToPalmAxis, rightHandUp);
             ik.solver.rightArm.target = rightHandAdjusterTransform;
+
+            ik.solver.rightArm.positionWeight = 1f;
+            ik.solver.rightArm.rotationWeight = 1f;
+            //TrackingWatcherにWeight設定用アクションを設定
+            RightHandTransform.parent.GetComponent<TrackingWatcher>().SetActionOfSetWeight((float weight) => {
+                ik.solver.rightArm.positionWeight = weight;
+                ik.solver.rightArm.rotationWeight = weight;
+            });
         }
         else
         {
@@ -435,6 +500,11 @@ public class Calibrator
             leftElbowAdjusterTransform.rotation = QuaTools.MatchRotation(LeftElbowTransform.rotation * Quaternion.LookRotation(settings.handTrackerForward, settings.handTrackerUp), settings.handTrackerForward, settings.handTrackerUp, ik.solver.leftArm.wristToPalmAxis, leftHandUp);
             ik.solver.leftArm.bendGoal = leftElbowAdjusterTransform;
             ik.solver.leftArm.bendGoalWeight = 1.0f;
+
+            //TrackingWatcherにWeight設定用アクションを設定
+            LeftElbowTransform.parent.GetComponent<TrackingWatcher>().SetActionOfSetWeight((float weight) => {
+                ik.solver.leftArm.bendGoalWeight = weight;
+            });
         }
         else
         {
@@ -451,6 +521,11 @@ public class Calibrator
             rightElbowAdjusterTransform.rotation = QuaTools.MatchRotation(RightElbowTransform.rotation * Quaternion.LookRotation(settings.handTrackerForward, settings.handTrackerUp), settings.handTrackerForward, settings.handTrackerUp, ik.solver.rightArm.wristToPalmAxis, rightHandUp);
             ik.solver.rightArm.bendGoal = rightElbowAdjusterTransform;
             ik.solver.rightArm.bendGoalWeight = 1.0f;
+
+            //TrackingWatcherにWeight設定用アクションを設定
+            RightElbowTransform.parent.GetComponent<TrackingWatcher>().SetActionOfSetWeight((float weight) => {
+                ik.solver.rightArm.bendGoalWeight = weight;
+            });
         }
         else
         {
@@ -476,6 +551,11 @@ public class Calibrator
             leftKneeAdjusterTransform.rotation = ik.references.leftCalf.rotation;// QuaTools.MatchRotation(LeftKneeTransform.rotation * Quaternion.LookRotation(settings.footTrackerForward, settings.footTrackerUp), settings.footTrackerForward, settings.footTrackerUp, Vector3.zero, leftHandUp);
             ik.solver.leftLeg.bendGoal = leftKneeAdjusterTransform;
             ik.solver.leftLeg.bendGoalWeight = 1.0f;
+
+            //TrackingWatcherにWeight設定用アクションを設定
+            LeftKneeTransform.parent.GetComponent<TrackingWatcher>().SetActionOfSetWeight((float weight) => {
+                ik.solver.leftLeg.bendGoalWeight = weight;
+            });
         }
 
         ik.solver.rightLeg.bendGoalWeight = 0.0f;
@@ -496,6 +576,11 @@ public class Calibrator
             rightKneeAdjusterTransform.rotation = ik.references.rightCalf.rotation;// QuaTools.MatchRotation(RightKneeTransform.rotation * Quaternion.LookRotation(settings.footTrackerForward, settings.footTrackerUp), settings.footTrackerForward, settings.footTrackerUp, Vector3.zero, rightHandUp);
             ik.solver.rightLeg.bendGoal = rightKneeAdjusterTransform;
             ik.solver.rightLeg.bendGoalWeight = 1.0f;
+
+            //TrackingWatcherにWeight設定用アクションを設定
+            RightKneeTransform.parent.GetComponent<TrackingWatcher>().SetActionOfSetWeight((float weight) => {
+                ik.solver.rightLeg.bendGoalWeight = weight;
+            });
         }
 
         // Root controller
@@ -544,6 +629,9 @@ public class Calibrator
             yield break;
         }
 
+        //TrackingWatcherを初期化する
+        GameObject.Find("HandTrackerRoot").GetComponent<sh_akira.OVRTracking.TrackerHandler>().ClearTrackingWatcher();
+
         //トラッカーのルートスケールを初期値に戻す
         handTrackerRoot.localScale = new Vector3(1.0f, 1.0f, 1.0f);
         headTrackerRoot.localScale = new Vector3(1.0f, 1.0f, 1.0f);
@@ -699,6 +787,11 @@ public class Calibrator
         ik.solver.spine.headTarget = hmdAdjusterTransform;
         ik.solver.spine.headClampWeight = 0.38f;
 
+        //TrackingWatcherにWeight設定用アクションを設定
+        HMDTransform.GetComponent<TrackingWatcher>().SetActionOfSetWeight((float weight) => {
+            //Do noting
+        });
+
         // Body
         if (PelvisTransform != null)
         {
@@ -709,6 +802,12 @@ public class Calibrator
             ik.solver.spine.pelvisTarget = pelvisAdjusterTransform;
             ik.solver.spine.pelvisPositionWeight = 1f;
             ik.solver.spine.pelvisRotationWeight = 1f;
+
+            //TrackingWatcherにWeight設定用アクションを設定
+            PelvisTransform.GetComponentInChildren<TrackingWatcher>().SetActionOfSetWeight((float weight) => {
+                ik.solver.spine.pelvisPositionWeight = weight;
+                ik.solver.spine.pelvisRotationWeight = weight;
+            });
 
             ik.solver.plantFeet = false;
             ik.solver.spine.neckStiffness = 0f;
@@ -732,6 +831,14 @@ public class Calibrator
             Vector3 leftHandUp = Vector3.Cross(ik.solver.leftArm.wristToPalmAxis, ik.solver.leftArm.palmToThumbAxis);
             leftHandAdjusterTransform.rotation = QuaTools.MatchRotation(LeftHandTransform.rotation * Quaternion.LookRotation(settings.handTrackerForward, settings.handTrackerUp), settings.handTrackerForward, settings.handTrackerUp, ik.solver.leftArm.wristToPalmAxis, leftHandUp);
             ik.solver.leftArm.target = leftHandAdjusterTransform;
+
+            ik.solver.leftArm.positionWeight = 1f;
+            ik.solver.leftArm.rotationWeight = 1f;
+            //TrackingWatcherにWeight設定用アクションを設定
+            LeftHandTransform.parent.GetComponent<TrackingWatcher>().SetActionOfSetWeight((float weight) => {
+                ik.solver.leftArm.positionWeight = weight;
+                ik.solver.leftArm.rotationWeight = weight;
+            });
         }
         else
         {
@@ -748,6 +855,14 @@ public class Calibrator
             Vector3 rightHandUp = -Vector3.Cross(ik.solver.rightArm.wristToPalmAxis, ik.solver.rightArm.palmToThumbAxis);
             rightHandAdjusterTransform.rotation = QuaTools.MatchRotation(RightHandTransform.rotation * Quaternion.LookRotation(settings.handTrackerForward, settings.handTrackerUp), settings.handTrackerForward, settings.handTrackerUp, ik.solver.rightArm.wristToPalmAxis, rightHandUp);
             ik.solver.rightArm.target = rightHandAdjusterTransform;
+
+            ik.solver.rightArm.positionWeight = 1f;
+            ik.solver.rightArm.rotationWeight = 1f;
+            //TrackingWatcherにWeight設定用アクションを設定
+            RightHandTransform.parent.GetComponent<TrackingWatcher>().SetActionOfSetWeight((float weight) => {
+                ik.solver.rightArm.positionWeight = weight;
+                ik.solver.rightArm.rotationWeight = weight;
+            });
         }
         else
         {
@@ -765,6 +880,11 @@ public class Calibrator
             leftElbowAdjusterTransform.rotation = QuaTools.MatchRotation(LeftElbowTransform.rotation * Quaternion.LookRotation(settings.handTrackerForward, settings.handTrackerUp), settings.handTrackerForward, settings.handTrackerUp, ik.solver.leftArm.wristToPalmAxis, leftHandUp);
             ik.solver.leftArm.bendGoal = leftElbowAdjusterTransform;
             ik.solver.leftArm.bendGoalWeight = 1.0f;
+
+            //TrackingWatcherにWeight設定用アクションを設定
+            LeftElbowTransform.parent.GetComponent<TrackingWatcher>().SetActionOfSetWeight((float weight) => {
+                ik.solver.leftArm.bendGoalWeight = weight;
+            });
         }
         else
         {
@@ -781,6 +901,11 @@ public class Calibrator
             rightElbowAdjusterTransform.rotation = QuaTools.MatchRotation(RightElbowTransform.rotation * Quaternion.LookRotation(settings.handTrackerForward, settings.handTrackerUp), settings.handTrackerForward, settings.handTrackerUp, ik.solver.rightArm.wristToPalmAxis, rightHandUp);
             ik.solver.rightArm.bendGoal = rightElbowAdjusterTransform;
             ik.solver.rightArm.bendGoalWeight = 1.0f;
+
+            //TrackingWatcherにWeight設定用アクションを設定
+            RightElbowTransform.parent.GetComponent<TrackingWatcher>().SetActionOfSetWeight((float weight) => {
+                ik.solver.rightArm.bendGoalWeight = weight;
+            });
         }
         else
         {
@@ -794,6 +919,11 @@ public class Calibrator
             var leftBendGoalTarget = CalibrateLeg(settings, LeftFootTransform, ik.solver.leftLeg, (ik.references.leftToes != null ? ik.references.leftToes : ik.references.leftFoot), hmdForwardAngle, ik.references.root.forward, true);
             ik.solver.leftLeg.bendGoal = leftBendGoalTarget;
             ik.solver.leftLeg.bendGoalWeight = 0.0f;
+
+            //TrackingWatcherにWeight設定用アクションを設定
+            LeftFootTransform.parent.GetComponent<TrackingWatcher>().SetActionOfSetWeight((float weight) => {
+                //Do noting
+            });
         }
 
         if (LeftKneeTransform != null)
@@ -806,6 +936,11 @@ public class Calibrator
             leftKneeAdjusterTransform.rotation = ik.references.leftCalf.rotation;// QuaTools.MatchRotation(LeftKneeTransform.rotation * Quaternion.LookRotation(settings.footTrackerForward, settings.footTrackerUp), settings.footTrackerForward, settings.footTrackerUp, Vector3.zero, leftHandUp);
             ik.solver.leftLeg.bendGoal = leftKneeAdjusterTransform;
             ik.solver.leftLeg.bendGoalWeight = 1.0f;
+
+            //TrackingWatcherにWeight設定用アクションを設定
+            LeftKneeTransform.parent.GetComponent<TrackingWatcher>().SetActionOfSetWeight((float weight) => {
+                ik.solver.leftLeg.bendGoalWeight = weight;
+            });
         }
 
         ik.solver.rightLeg.bendGoalWeight = 0.0f;
@@ -814,6 +949,11 @@ public class Calibrator
             var rightBendGoalTarget = CalibrateLeg(settings, RightFootTransform, ik.solver.rightLeg, (ik.references.rightToes != null ? ik.references.rightToes : ik.references.rightFoot), hmdForwardAngle, ik.references.root.forward, false);
             ik.solver.rightLeg.bendGoal = rightBendGoalTarget;
             ik.solver.rightLeg.bendGoalWeight = 0.0f;
+
+            //TrackingWatcherにWeight設定用アクションを設定
+            RightFootTransform.parent.GetComponent<TrackingWatcher>().SetActionOfSetWeight((float weight) => {
+                //Do noting
+            });
         }
 
         if (RightKneeTransform != null)
@@ -826,6 +966,11 @@ public class Calibrator
             rightKneeAdjusterTransform.rotation = ik.references.rightCalf.rotation;// QuaTools.MatchRotation(RightKneeTransform.rotation * Quaternion.LookRotation(settings.footTrackerForward, settings.footTrackerUp), settings.footTrackerForward, settings.footTrackerUp, Vector3.zero, rightHandUp);
             ik.solver.rightLeg.bendGoal = rightKneeAdjusterTransform;
             ik.solver.rightLeg.bendGoalWeight = 1.0f;
+
+            //TrackingWatcherにWeight設定用アクションを設定
+            RightKneeTransform.parent.GetComponent<TrackingWatcher>().SetActionOfSetWeight((float weight) => {
+                ik.solver.rightLeg.bendGoalWeight = weight;
+            });
         }
 
         // Root controller
@@ -874,6 +1019,9 @@ public class Calibrator
             yield break;
         }
 
+        //TrackingWatcherを初期化する
+        GameObject.Find("HandTrackerRoot").GetComponent<sh_akira.OVRTracking.TrackerHandler>().ClearTrackingWatcher();
+
         //トラッカーのルートスケールを初期値に戻す
         handTrackerRoot.localScale = new Vector3(1.0f, 1.0f, 1.0f);
         headTrackerRoot.localScale = new Vector3(1.0f, 1.0f, 1.0f);
@@ -1029,6 +1177,11 @@ public class Calibrator
         ik.solver.spine.headTarget = hmdAdjusterTransform;
         ik.solver.spine.headClampWeight = 0.38f;
 
+        //TrackingWatcherにWeight設定用アクションを設定
+        HMDTransform.GetComponent<TrackingWatcher>().SetActionOfSetWeight((float weight) => {
+            //Do noting
+        });
+
         // Body
         if (PelvisTransform != null)
         {
@@ -1039,6 +1192,12 @@ public class Calibrator
             ik.solver.spine.pelvisTarget = pelvisAdjusterTransform;
             ik.solver.spine.pelvisPositionWeight = 1f;
             ik.solver.spine.pelvisRotationWeight = 1f;
+
+            //TrackingWatcherにWeight設定用アクションを設定
+            PelvisTransform.GetComponentInChildren<TrackingWatcher>().SetActionOfSetWeight((float weight) => {
+                ik.solver.spine.pelvisPositionWeight = weight;
+                ik.solver.spine.pelvisRotationWeight = weight;
+            });
 
             ik.solver.plantFeet = false;
             ik.solver.spine.neckStiffness = 0f;
@@ -1062,6 +1221,12 @@ public class Calibrator
             Vector3 leftHandUp = Vector3.Cross(ik.solver.leftArm.wristToPalmAxis, ik.solver.leftArm.palmToThumbAxis);
             leftHandAdjusterTransform.rotation = QuaTools.MatchRotation(LeftHandTransform.rotation * Quaternion.LookRotation(settings.handTrackerForward, settings.handTrackerUp), settings.handTrackerForward, settings.handTrackerUp, ik.solver.leftArm.wristToPalmAxis, leftHandUp);
             ik.solver.leftArm.target = leftHandAdjusterTransform;
+
+            //TrackingWatcherにWeight設定用アクションを設定
+            LeftHandTransform.parent.GetComponent<TrackingWatcher>().SetActionOfSetWeight((float weight) => {
+                ik.solver.leftArm.positionWeight = weight;
+                ik.solver.leftArm.rotationWeight = weight;
+            });
         }
         else
         {
@@ -1078,6 +1243,12 @@ public class Calibrator
             Vector3 rightHandUp = -Vector3.Cross(ik.solver.rightArm.wristToPalmAxis, ik.solver.rightArm.palmToThumbAxis);
             rightHandAdjusterTransform.rotation = QuaTools.MatchRotation(RightHandTransform.rotation * Quaternion.LookRotation(settings.handTrackerForward, settings.handTrackerUp), settings.handTrackerForward, settings.handTrackerUp, ik.solver.rightArm.wristToPalmAxis, rightHandUp);
             ik.solver.rightArm.target = rightHandAdjusterTransform;
+
+            //TrackingWatcherにWeight設定用アクションを設定
+            RightHandTransform.parent.GetComponent<TrackingWatcher>().SetActionOfSetWeight((float weight) => {
+                ik.solver.rightArm.positionWeight = weight;
+                ik.solver.rightArm.rotationWeight = weight;
+            });
         }
         else
         {
@@ -1095,6 +1266,11 @@ public class Calibrator
             leftElbowAdjusterTransform.rotation = QuaTools.MatchRotation(LeftElbowTransform.rotation * Quaternion.LookRotation(settings.handTrackerForward, settings.handTrackerUp), settings.handTrackerForward, settings.handTrackerUp, ik.solver.leftArm.wristToPalmAxis, leftHandUp);
             ik.solver.leftArm.bendGoal = leftElbowAdjusterTransform;
             ik.solver.leftArm.bendGoalWeight = 1.0f;
+
+            //TrackingWatcherにWeight設定用アクションを設定
+            LeftElbowTransform.parent.GetComponent<TrackingWatcher>().SetActionOfSetWeight((float weight) => {
+                ik.solver.leftArm.bendGoalWeight = weight;
+            });
         }
         else
         {
@@ -1111,6 +1287,11 @@ public class Calibrator
             rightElbowAdjusterTransform.rotation = QuaTools.MatchRotation(RightElbowTransform.rotation * Quaternion.LookRotation(settings.handTrackerForward, settings.handTrackerUp), settings.handTrackerForward, settings.handTrackerUp, ik.solver.rightArm.wristToPalmAxis, rightHandUp);
             ik.solver.rightArm.bendGoal = rightElbowAdjusterTransform;
             ik.solver.rightArm.bendGoalWeight = 1.0f;
+
+            //TrackingWatcherにWeight設定用アクションを設定
+            RightElbowTransform.parent.GetComponent<TrackingWatcher>().SetActionOfSetWeight((float weight) => {
+                ik.solver.rightArm.bendGoalWeight = weight;
+            });
         }
         else
         {
@@ -1124,6 +1305,11 @@ public class Calibrator
             var leftBendGoalTarget = CalibrateLeg(settings, LeftFootTransform, ik.solver.leftLeg, (ik.references.leftToes != null ? ik.references.leftToes : ik.references.leftFoot), hmdForwardAngle, ik.references.root.forward, true);
             ik.solver.leftLeg.bendGoal = leftBendGoalTarget;
             ik.solver.leftLeg.bendGoalWeight = 0.0f;
+
+            //TrackingWatcherにWeight設定用アクションを設定
+            LeftFootTransform.parent.GetComponent<TrackingWatcher>().SetActionOfSetWeight((float weight) => {
+                //Do noting
+            });
         }
 
         if (LeftKneeTransform != null)
@@ -1136,6 +1322,11 @@ public class Calibrator
             leftKneeAdjusterTransform.rotation = ik.references.leftCalf.rotation;// QuaTools.MatchRotation(LeftKneeTransform.rotation * Quaternion.LookRotation(settings.footTrackerForward, settings.footTrackerUp), settings.footTrackerForward, settings.footTrackerUp, Vector3.zero, leftHandUp);
             ik.solver.leftLeg.bendGoal = leftKneeAdjusterTransform;
             ik.solver.leftLeg.bendGoalWeight = 1.0f;
+
+            //TrackingWatcherにWeight設定用アクションを設定
+            LeftKneeTransform.parent.GetComponent<TrackingWatcher>().SetActionOfSetWeight((float weight) => {
+                ik.solver.leftLeg.bendGoalWeight = weight;
+            });
         }
 
         ik.solver.rightLeg.bendGoalWeight = 0.0f;
@@ -1144,6 +1335,9 @@ public class Calibrator
             var rightBendGoalTarget = CalibrateLeg(settings, RightFootTransform, ik.solver.rightLeg, (ik.references.rightToes != null ? ik.references.rightToes : ik.references.rightFoot), hmdForwardAngle, ik.references.root.forward, false);
             ik.solver.rightLeg.bendGoal = rightBendGoalTarget;
             ik.solver.rightLeg.bendGoalWeight = 0.0f;
+            RightFootTransform.parent.GetComponent<TrackingWatcher>().SetActionOfSetWeight((float weight) => {
+                //Do noting
+            });
         }
 
         if (RightKneeTransform != null)
@@ -1156,6 +1350,11 @@ public class Calibrator
             rightKneeAdjusterTransform.rotation = ik.references.rightCalf.rotation;// QuaTools.MatchRotation(RightKneeTransform.rotation * Quaternion.LookRotation(settings.footTrackerForward, settings.footTrackerUp), settings.footTrackerForward, settings.footTrackerUp, Vector3.zero, rightHandUp);
             ik.solver.rightLeg.bendGoal = rightKneeAdjusterTransform;
             ik.solver.rightLeg.bendGoalWeight = 1.0f;
+
+            //TrackingWatcherにWeight設定用アクションを設定
+            RightKneeTransform.parent.GetComponent<TrackingWatcher>().SetActionOfSetWeight((float weight) => {
+                ik.solver.rightLeg.bendGoalWeight = weight;
+            });
         }
 
         // Root controller

--- a/Assets/Scripts/ControlWPFWindow.cs
+++ b/Assets/Scripts/ControlWPFWindow.cs
@@ -1495,6 +1495,8 @@ public class ControlWPFWindow : MonoBehaviour
 
     private void SetVRIKTargetTrackers()
     {
+        if (vrik == null) { return; } //まだmodelがない
+
         vrik.solver.spine.headTarget = GetTrackerTransformBySerialNumber(CurrentSettings.Head, TargetType.Head);
         vrik.solver.spine.headClampWeight = 0.38f;
 


### PR DESCRIPTION
以下を追加しました。
・トラッキング状態に応じたIK Weightの自動操作(既定で無効)
・トラッキングを一度もしていないデバイスの除外(GamePadバグ修正)
・Audio Listenerの無効化と代表Audio Listenerの追加(キャリブレーション時の大量ログ出力抑止)
・Tracker HandlerがExternal Receiverを読み込んでいないバグ修正
・使用していないキャリブレーションコードのコメントアウト
・null参照バグの一部修正

以下の注意点があります。
・キャリブレーション処理にかなり変更が入っています。
　これに伴い、各トラッキングポジションごとにエラーが起きうるので、最大点数での
　トラッキングでの動作確認をお願いします。(手持ちの環境では無理なので...)
・トラッキング状態に応じたIK Weightの自動操作を入れましたが、既定で無効です。
　これは、手などのWeightを切ると、逆に「飛んでいる」ように見えるためです。
　場所ごとに有効無効にする、調整するなどの味付けはおまかせします。
　(Calibrator.csでのラムダ関数を調整すると良いと思います)
・今回始めてUnity環境まるごとコミットしていますので、変な変更があったら直していただきますようお願いします。