### PR TITLE
左右コントローラーのボタンが入れ替わっちゃう問題への対処

### DIFF
--- a/Assets/ExternalPlugins/OVRTracking/Scripts/OpenVRWrapper.cs
+++ b/Assets/ExternalPlugins/OVRTracking/Scripts/OpenVRWrapper.cs
@@ -178,6 +178,29 @@ namespace sh_akira.OVRTracking
             return en;
         }
 
+        //コントローラ状態を調べる
+        public void GetControllerSerial(out string LeftHandSerial, out string RightHandSerial) {
+            LeftHandSerial = null;
+            RightHandSerial = null;
+
+            uint leftHandIndex = openVR.GetTrackedDeviceIndexForControllerRole(ETrackedControllerRole.LeftHand);
+            uint rightHandIndex = openVR.GetTrackedDeviceIndexForControllerRole(ETrackedControllerRole.RightHand);
+
+            if (serialNumbers == null || (leftHandIndex == OpenVR.k_unTrackedDeviceIndexInvalid) || (rightHandIndex == OpenVR.k_unTrackedDeviceIndexInvalid))
+            {
+                return;
+            }
+
+            try
+            {
+                LeftHandSerial = serialNumbers[leftHandIndex];
+                RightHandSerial = serialNumbers[rightHandIndex];
+            }
+            catch (IndexOutOfRangeException) {
+                return;
+            }
+        }
+
         public void Close()
         {
             openVR = null;

--- a/Assets/HandSwapManagerScript.cs
+++ b/Assets/HandSwapManagerScript.cs
@@ -1,0 +1,60 @@
+﻿//gpsnmeajp
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using sh_akira.OVRTracking;
+
+public class HandSwapManagerScript : MonoBehaviour {
+    public bool Enable = true;
+
+    [Header("OpenVR (Input)")]
+    public string OpenVRLeftHand;
+    public string OpenVRRightHand;
+
+    [Header("WPF (Input)")]
+    public Transform WPFLeftHandTransform;
+    public Transform WPFRightHandTransform;
+    public string WPFLeftHand;
+    public string WPFRightHand;
+
+    [Header("Output")]
+    public bool HandSwap = false;
+    public SteamVR2Input steamVR2Input = null;
+
+    void Start () {
+		
+	}
+	
+	void Update () {
+        if (!Enable) {
+            return;
+        }
+
+        if (WPFLeftHandTransform) {
+            WPFLeftHand = WPFLeftHandTransform.name;
+            if (WPFLeftHand != null) {
+                WPFLeftHand = WPFLeftHand.Replace("[Controller]", "");
+            }
+        }
+        if (WPFRightHandTransform) {
+            WPFRightHand = WPFRightHandTransform.name;
+            if (WPFRightHand != null)
+            {
+                WPFRightHand = WPFRightHand.Replace("[Controller]", "");
+            }
+        }
+
+        OpenVRWrapper.Instance.GetControllerSerial(out OpenVRLeftHand, out OpenVRRightHand);
+
+        if (OpenVRLeftHand == WPFRightHand && OpenVRRightHand == WPFLeftHand)
+        {
+            HandSwap = true;
+            steamVR2Input.handSwap = true;
+        }
+        else {
+            HandSwap = false;
+            steamVR2Input.handSwap = false;
+        }
+    }
+}

--- a/Assets/HandSwapManagerScript.cs.meta
+++ b/Assets/HandSwapManagerScript.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 89af86d3dc2039647b6a14d1967186a2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/VirtualMotionCapture.unity
+++ b/Assets/Scenes/VirtualMotionCapture.unity
@@ -385,6 +385,7 @@ MonoBehaviour:
   skeletalTransformSpace: 0
   handTracking_Skeletal: {fileID: 483683249}
   EnableSkeletal: 1
+  handSwap: 0
 --- !u!4 &130023281
 Transform:
   m_ObjectHideFlags: 0
@@ -1814,6 +1815,55 @@ MonoBehaviour:
   LookOffset: {x: 0, y: 0.05, z: 0}
   PositionFixedTarget: {fileID: 0}
   RelativePosition: {x: 0, y: 0, z: -1}
+--- !u!1 &283794701
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 283794702}
+  - component: {fileID: 283794703}
+  m_Layer: 0
+  m_Name: HandSwapManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &283794702
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 283794701}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1177174446}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &283794703
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 283794701}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 89af86d3dc2039647b6a14d1967186a2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Enable: 1
+  OpenVRLeftHand: 
+  OpenVRRightHand: 
+  WPFLeftHandTransform: {fileID: 0}
+  WPFRightHandTransform: {fileID: 0}
+  WPFLeftHand: 
+  WPFRightHand: 
+  HandSwap: 0
+  steamVR2Input: {fileID: 130023280}
 --- !u!1 &302272467
 GameObject:
   m_ObjectHideFlags: 0
@@ -1986,18 +2036,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c6fd25003140c0e47b39261ea2e0f470, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  MonitorPosition: {fileID: 0}
-  LookTarget: {fileID: 0}
-  StartPos: {x: 0, y: 0, z: 0}
-  ScaleX: 0.5
-  ScaleY: 0.2
-  OffsetX: 0
-  OffsetY: 0
-  CenterX: 0.5
-  CenterY: 0.5
-  Smoothing: 0.7
-  controlWPFWindow: {fileID: 1407685704}
-  faceController: {fileID: 69806225}
 --- !u!4 &326004793
 Transform:
   m_ObjectHideFlags: 0
@@ -2022,19 +2060,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 1fd512d95b6700d44a5763b8c74b228a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  MonitorPosition: {fileID: 0}
-  LookTarget: {fileID: 0}
-  StartPos: {x: 0, y: 0, z: 0}
-  ScaleX: 2
-  ScaleY: 1.5
-  OffsetX: 0
-  OffsetY: 0
-  CenterX: 0.5
-  CenterY: 0.5
-  Smoothing: 0.7
-  controlWPFWindow: {fileID: 1407685704}
-  faceController: {fileID: 69806225}
-  UseEyelidMovements: 1
 --- !u!114 &326004795
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2046,9 +2071,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 47613961cde0a8b4aa4f79219b7e523c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  EnableEye: 1
-  EnableEyeDataCallback: 0
-  EnableEyeVersion: 0
 --- !u!1 &378345255
 GameObject:
   m_ObjectHideFlags: 0
@@ -5535,12 +5557,12 @@ Transform:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1044902095}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
-  m_Father: {fileID: 0}
-  m_RootOrder: 30
+  m_Father: {fileID: 1177174446}
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1049932826
 GameObject:
@@ -6250,6 +6272,36 @@ Transform:
   - {fileID: 415054483}
   m_Father: {fileID: 1300838139}
   m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1177174445
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1177174446}
+  m_Layer: 0
+  m_Name: Manager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1177174446
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1177174445}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1044902097}
+  - {fileID: 283794702}
+  m_Father: {fileID: 0}
+  m_RootOrder: 30
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1191951026
 GameObject:
@@ -10374,8 +10426,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: b2f7a0c5fd055af4083cbe934b512f19, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  controlWPFWindow: {fileID: 1407685704}
-  sdkConfiguration: {fileID: 11400000, guid: dd276808621df4e2380660ade912baf3, type: 2}
 --- !u!4 &1770264196
 Transform:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Calibrator.cs
+++ b/Assets/Scripts/Calibrator.cs
@@ -265,6 +265,11 @@ public class Calibrator
         if (LeftKneeTransform != null) LeftKneeTransform.parent = footTrackerRoot;
         if (RightKneeTransform != null) RightKneeTransform.parent = footTrackerRoot;
 
+        HandSwapManagerScript handSwapManagerScript = GameObject.Find("HandSwapManager").GetComponent<HandSwapManagerScript>();
+        handSwapManagerScript.WPFLeftHandTransform = LeftHandTransform; //左手登録
+        handSwapManagerScript.WPFRightHandTransform = RightHandTransform; //右手登録
+
+
         //コントローラーの場合手首までのオフセットを追加
         if (LeftHandOffset == Vector3.zero)
         {
@@ -654,6 +659,9 @@ public class Calibrator
         var pelvisOffsetAdjuster = new GameObject("PelvisOffsetAdjuster").transform;
         pelvisOffsetAdjuster.parent = footTrackerRoot;
 
+        HandSwapManagerScript handSwapManagerScript = GameObject.Find("HandSwapManager").GetComponent<HandSwapManagerScript>();
+        handSwapManagerScript.WPFLeftHandTransform = LeftHandTransform; //左手登録
+        handSwapManagerScript.WPFRightHandTransform = RightHandTransform; //右手登録
 
         //それぞれのトラッカーを正しいルートに移動
         if (HMDTransform != null) HMDTransform.parent = headTrackerRoot;
@@ -1044,6 +1052,9 @@ public class Calibrator
         var pelvisOffsetAdjuster = new GameObject("PelvisOffsetAdjuster").transform;
         pelvisOffsetAdjuster.parent = footTrackerRoot;
 
+        HandSwapManagerScript handSwapManagerScript = GameObject.Find("HandSwapManager").GetComponent<HandSwapManagerScript>();
+        handSwapManagerScript.WPFLeftHandTransform = LeftHandTransform; //左手登録
+        handSwapManagerScript.WPFRightHandTransform = RightHandTransform; //右手登録
 
         //それぞれのトラッカーを正しいルートに移動
         if (HMDTransform != null) HMDTransform.parent = headTrackerRoot;

--- a/Assets/Scripts/SteamVRWrapper2.0/SteamVR2Input.cs
+++ b/Assets/Scripts/SteamVRWrapper2.0/SteamVR2Input.cs
@@ -34,6 +34,7 @@ public class SteamVR2Input : MonoBehaviour
 
     private SteamVRActions CurrentActionData;
 
+    public bool handSwap = false;
 
     void OnEnable()
     {
@@ -178,7 +179,7 @@ public class SteamVR2Input : MonoBehaviour
                         ulActionSet = actionSetHandle,
                         ulRestrictedToDevice = inputSourceHandle,
                         InputSourcePath = inputSourcePath,
-                        IsLeft = inputSourcePath.Contains("left"),
+                        IsLeft = inputSourcePath.Contains("left") != handSwap,
                     });
                 }
             }
@@ -218,7 +219,7 @@ public class SteamVR2Input : MonoBehaviour
 
                         bool isTouch = action.ShortName.StartsWith("Touch") && action.ShortName.Contains("Trigger") == false;
                         Vector3 axis = isTouch ? GetLastPosition(action.ShortName) : Vector3.zero;
-                        KeyDownEvent?.Invoke(this, new OVRKeyEventArgs(action.ShortName, axis, actionset.IsLeft, axis != Vector3.zero, isTouch));
+                        KeyDownEvent?.Invoke(this, new OVRKeyEventArgs(action.ShortName, axis, actionset.IsLeft != handSwap, axis != Vector3.zero, isTouch));
                     }
                     if (IsKeyUp(action.digitalActionData))
                     {
@@ -226,7 +227,7 @@ public class SteamVR2Input : MonoBehaviour
 
                         bool isTouch = action.ShortName.StartsWith("Touch") && action.ShortName.Contains("Trigger") == false;
                         Vector3 axis = isTouch ? GetLastPosition(action.ShortName) : Vector3.zero;
-                        KeyUpEvent?.Invoke(this, new OVRKeyEventArgs(action.ShortName, axis, actionset.IsLeft, axis != Vector3.zero, isTouch));
+                        KeyUpEvent?.Invoke(this, new OVRKeyEventArgs(action.ShortName, axis, actionset.IsLeft != handSwap, axis != Vector3.zero, isTouch));
                     }
                 }
                 else if (action.type == "vector1" || action.type == "vector2" || action.type == "vector3")
@@ -244,7 +245,7 @@ public class SteamVR2Input : MonoBehaviour
                     if (axis != Vector3.zero)
                     {
                         LastPositions[action.name] = axis;
-                        AxisChangedEvent?.Invoke(this, new OVRKeyEventArgs(action.ShortName, axis, actionset.IsLeft, true, false));
+                        AxisChangedEvent?.Invoke(this, new OVRKeyEventArgs(action.ShortName, axis, actionset.IsLeft != handSwap, true, false));
                     }
                 }
                 else if (action.type == "skeleton")
@@ -261,7 +262,7 @@ public class SteamVR2Input : MonoBehaviour
                             //Debug.LogWarning($"<b>[SteamVR]</b> GetDigitalActionData error ({action.name}): {err} handle: {action.handle}");
                             continue;
                         }
-                        handTracking_Skeletal.SetSkeltalBoneData(action.name.Contains("Left"), tempBoneTransforms);
+                        handTracking_Skeletal.SetSkeltalBoneData(action.name.Contains("Left") != handSwap, tempBoneTransforms);
                     }
                 }
             }


### PR DESCRIPTION
OpenVR側の認識と、ばもきゃ側で持っている左右の手の認識が
コントローラのスリープのタイミングで入れ替わる問題に対処しました。

2つの認識状態を突き合わせ、確実に入れ替わっているときには
SteamVR2Inputの入力の左右を反転させます。

これにより、ボタン操作やスティック、手の形状などが動的に入れ替わります。
(Indexで意図的に左右入れ替えた場合のみテストしています。VIVEなどの場合は別途テストしていただきたいです)