### PR TITLE
Unity LogのWPF画面出力機能、デザイン調整、ヘルプタブの追加

### DIFF
--- a/Assets/ExternalPlugins/OVRTracking/Scripts/OpenVRWrapper.cs
+++ b/Assets/ExternalPlugins/OVRTracking/Scripts/OpenVRWrapper.cs
@@ -178,6 +178,29 @@ namespace sh_akira.OVRTracking
             return en;
         }
 
+        //コントローラ状態を調べる
+        public void GetControllerSerial(out string LeftHandSerial, out string RightHandSerial) {
+            LeftHandSerial = null;
+            RightHandSerial = null;
+
+            uint leftHandIndex = openVR.GetTrackedDeviceIndexForControllerRole(ETrackedControllerRole.LeftHand);
+            uint rightHandIndex = openVR.GetTrackedDeviceIndexForControllerRole(ETrackedControllerRole.RightHand);
+
+            if (serialNumbers == null || (leftHandIndex == OpenVR.k_unTrackedDeviceIndexInvalid) || (rightHandIndex == OpenVR.k_unTrackedDeviceIndexInvalid))
+            {
+                return;
+            }
+
+            try
+            {
+                LeftHandSerial = serialNumbers[leftHandIndex];
+                RightHandSerial = serialNumbers[rightHandIndex];
+            }
+            catch (IndexOutOfRangeException) {
+                return;
+            }
+        }
+
         public void Close()
         {
             openVR = null;

--- a/Assets/HandSwapManagerScript.cs
+++ b/Assets/HandSwapManagerScript.cs
@@ -1,0 +1,60 @@
+﻿//gpsnmeajp
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using sh_akira.OVRTracking;
+
+public class HandSwapManagerScript : MonoBehaviour {
+    public bool Enable = true;
+
+    [Header("OpenVR (Input)")]
+    public string OpenVRLeftHand;
+    public string OpenVRRightHand;
+
+    [Header("WPF (Input)")]
+    public Transform WPFLeftHandTransform;
+    public Transform WPFRightHandTransform;
+    public string WPFLeftHand;
+    public string WPFRightHand;
+
+    [Header("Output")]
+    public bool HandSwap = false;
+    public SteamVR2Input steamVR2Input = null;
+
+    void Start () {
+		
+	}
+	
+	void Update () {
+        if (!Enable) {
+            return;
+        }
+
+        if (WPFLeftHandTransform) {
+            WPFLeftHand = WPFLeftHandTransform.name;
+            if (WPFLeftHand != null) {
+                WPFLeftHand = WPFLeftHand.Replace("[Controller]", "");
+            }
+        }
+        if (WPFRightHandTransform) {
+            WPFRightHand = WPFRightHandTransform.name;
+            if (WPFRightHand != null)
+            {
+                WPFRightHand = WPFRightHand.Replace("[Controller]", "");
+            }
+        }
+
+        OpenVRWrapper.Instance.GetControllerSerial(out OpenVRLeftHand, out OpenVRRightHand);
+
+        if (OpenVRLeftHand == WPFRightHand && OpenVRRightHand == WPFLeftHand)
+        {
+            HandSwap = true;
+            steamVR2Input.handSwap = true;
+        }
+        else {
+            HandSwap = false;
+            steamVR2Input.handSwap = false;
+        }
+    }
+}

--- a/Assets/HandSwapManagerScript.cs.meta
+++ b/Assets/HandSwapManagerScript.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 89af86d3dc2039647b6a14d1967186a2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/VirtualMotionCapture.unity
+++ b/Assets/Scenes/VirtualMotionCapture.unity
@@ -385,6 +385,7 @@ MonoBehaviour:
   skeletalTransformSpace: 0
   handTracking_Skeletal: {fileID: 483683249}
   EnableSkeletal: 1
+  handSwap: 0
 --- !u!4 &130023281
 Transform:
   m_ObjectHideFlags: 0
@@ -1814,6 +1815,55 @@ MonoBehaviour:
   LookOffset: {x: 0, y: 0.05, z: 0}
   PositionFixedTarget: {fileID: 0}
   RelativePosition: {x: 0, y: 0, z: -1}
+--- !u!1 &283794701
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 283794702}
+  - component: {fileID: 283794703}
+  m_Layer: 0
+  m_Name: HandSwapManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &283794702
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 283794701}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1177174446}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &283794703
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 283794701}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 89af86d3dc2039647b6a14d1967186a2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Enable: 1
+  OpenVRLeftHand: 
+  OpenVRRightHand: 
+  WPFLeftHandTransform: {fileID: 0}
+  WPFRightHandTransform: {fileID: 0}
+  WPFLeftHand: 
+  WPFRightHand: 
+  HandSwap: 0
+  steamVR2Input: {fileID: 130023280}
 --- !u!1 &302272467
 GameObject:
   m_ObjectHideFlags: 0
@@ -1986,18 +2036,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c6fd25003140c0e47b39261ea2e0f470, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  MonitorPosition: {fileID: 0}
-  LookTarget: {fileID: 0}
-  StartPos: {x: 0, y: 0, z: 0}
-  ScaleX: 0.5
-  ScaleY: 0.2
-  OffsetX: 0
-  OffsetY: 0
-  CenterX: 0.5
-  CenterY: 0.5
-  Smoothing: 0.7
-  controlWPFWindow: {fileID: 1407685704}
-  faceController: {fileID: 69806225}
 --- !u!4 &326004793
 Transform:
   m_ObjectHideFlags: 0
@@ -2022,19 +2060,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 1fd512d95b6700d44a5763b8c74b228a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  MonitorPosition: {fileID: 0}
-  LookTarget: {fileID: 0}
-  StartPos: {x: 0, y: 0, z: 0}
-  ScaleX: 2
-  ScaleY: 1.5
-  OffsetX: 0
-  OffsetY: 0
-  CenterX: 0.5
-  CenterY: 0.5
-  Smoothing: 0.7
-  controlWPFWindow: {fileID: 1407685704}
-  faceController: {fileID: 69806225}
-  UseEyelidMovements: 1
 --- !u!114 &326004795
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2046,9 +2071,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 47613961cde0a8b4aa4f79219b7e523c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  EnableEye: 1
-  EnableEyeDataCallback: 0
-  EnableEyeVersion: 0
 --- !u!1 &378345255
 GameObject:
   m_ObjectHideFlags: 0
@@ -5535,12 +5557,12 @@ Transform:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1044902095}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
-  m_Father: {fileID: 0}
-  m_RootOrder: 30
+  m_Father: {fileID: 1177174446}
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1049932826
 GameObject:
@@ -6250,6 +6272,36 @@ Transform:
   - {fileID: 415054483}
   m_Father: {fileID: 1300838139}
   m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1177174445
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1177174446}
+  m_Layer: 0
+  m_Name: Manager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1177174446
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1177174445}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1044902097}
+  - {fileID: 283794702}
+  m_Father: {fileID: 0}
+  m_RootOrder: 30
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1191951026
 GameObject:
@@ -10374,8 +10426,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: b2f7a0c5fd055af4083cbe934b512f19, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  controlWPFWindow: {fileID: 1407685704}
-  sdkConfiguration: {fileID: 11400000, guid: dd276808621df4e2380660ade912baf3, type: 2}
 --- !u!4 &1770264196
 Transform:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Calibrator.cs
+++ b/Assets/Scripts/Calibrator.cs
@@ -265,6 +265,11 @@ public class Calibrator
         if (LeftKneeTransform != null) LeftKneeTransform.parent = footTrackerRoot;
         if (RightKneeTransform != null) RightKneeTransform.parent = footTrackerRoot;
 
+        HandSwapManagerScript handSwapManagerScript = GameObject.Find("HandSwapManager").GetComponent<HandSwapManagerScript>();
+        handSwapManagerScript.WPFLeftHandTransform = LeftHandTransform; //左手登録
+        handSwapManagerScript.WPFRightHandTransform = RightHandTransform; //右手登録
+
+
         //コントローラーの場合手首までのオフセットを追加
         if (LeftHandOffset == Vector3.zero)
         {
@@ -654,6 +659,9 @@ public class Calibrator
         var pelvisOffsetAdjuster = new GameObject("PelvisOffsetAdjuster").transform;
         pelvisOffsetAdjuster.parent = footTrackerRoot;
 
+        HandSwapManagerScript handSwapManagerScript = GameObject.Find("HandSwapManager").GetComponent<HandSwapManagerScript>();
+        handSwapManagerScript.WPFLeftHandTransform = LeftHandTransform; //左手登録
+        handSwapManagerScript.WPFRightHandTransform = RightHandTransform; //右手登録
 
         //それぞれのトラッカーを正しいルートに移動
         if (HMDTransform != null) HMDTransform.parent = headTrackerRoot;
@@ -1044,6 +1052,9 @@ public class Calibrator
         var pelvisOffsetAdjuster = new GameObject("PelvisOffsetAdjuster").transform;
         pelvisOffsetAdjuster.parent = footTrackerRoot;
 
+        HandSwapManagerScript handSwapManagerScript = GameObject.Find("HandSwapManager").GetComponent<HandSwapManagerScript>();
+        handSwapManagerScript.WPFLeftHandTransform = LeftHandTransform; //左手登録
+        handSwapManagerScript.WPFRightHandTransform = RightHandTransform; //右手登録
 
         //それぞれのトラッカーを正しいルートに移動
         if (HMDTransform != null) HMDTransform.parent = headTrackerRoot;

--- a/Assets/Scripts/SteamVRWrapper2.0/SteamVR2Input.cs
+++ b/Assets/Scripts/SteamVRWrapper2.0/SteamVR2Input.cs
@@ -34,6 +34,7 @@ public class SteamVR2Input : MonoBehaviour
 
     private SteamVRActions CurrentActionData;
 
+    public bool handSwap = false;
 
     void OnEnable()
     {
@@ -178,7 +179,7 @@ public class SteamVR2Input : MonoBehaviour
                         ulActionSet = actionSetHandle,
                         ulRestrictedToDevice = inputSourceHandle,
                         InputSourcePath = inputSourcePath,
-                        IsLeft = inputSourcePath.Contains("left"),
+                        IsLeft = inputSourcePath.Contains("left") != handSwap,
                     });
                 }
             }
@@ -218,7 +219,7 @@ public class SteamVR2Input : MonoBehaviour
 
                         bool isTouch = action.ShortName.StartsWith("Touch") && action.ShortName.Contains("Trigger") == false;
                         Vector3 axis = isTouch ? GetLastPosition(action.ShortName) : Vector3.zero;
-                        KeyDownEvent?.Invoke(this, new OVRKeyEventArgs(action.ShortName, axis, actionset.IsLeft, axis != Vector3.zero, isTouch));
+                        KeyDownEvent?.Invoke(this, new OVRKeyEventArgs(action.ShortName, axis, actionset.IsLeft != handSwap, axis != Vector3.zero, isTouch));
                     }
                     if (IsKeyUp(action.digitalActionData))
                     {
@@ -226,7 +227,7 @@ public class SteamVR2Input : MonoBehaviour
 
                         bool isTouch = action.ShortName.StartsWith("Touch") && action.ShortName.Contains("Trigger") == false;
                         Vector3 axis = isTouch ? GetLastPosition(action.ShortName) : Vector3.zero;
-                        KeyUpEvent?.Invoke(this, new OVRKeyEventArgs(action.ShortName, axis, actionset.IsLeft, axis != Vector3.zero, isTouch));
+                        KeyUpEvent?.Invoke(this, new OVRKeyEventArgs(action.ShortName, axis, actionset.IsLeft != handSwap, axis != Vector3.zero, isTouch));
                     }
                 }
                 else if (action.type == "vector1" || action.type == "vector2" || action.type == "vector3")
@@ -244,7 +245,7 @@ public class SteamVR2Input : MonoBehaviour
                     if (axis != Vector3.zero)
                     {
                         LastPositions[action.name] = axis;
-                        AxisChangedEvent?.Invoke(this, new OVRKeyEventArgs(action.ShortName, axis, actionset.IsLeft, true, false));
+                        AxisChangedEvent?.Invoke(this, new OVRKeyEventArgs(action.ShortName, axis, actionset.IsLeft != handSwap, true, false));
                     }
                 }
                 else if (action.type == "skeleton")
@@ -261,7 +262,7 @@ public class SteamVR2Input : MonoBehaviour
                             //Debug.LogWarning($"<b>[SteamVR]</b> GetDigitalActionData error ({action.name}): {err} handle: {action.handle}");
                             continue;
                         }
-                        handTracking_Skeletal.SetSkeltalBoneData(action.name.Contains("Left"), tempBoneTransforms);
+                        handTracking_Skeletal.SetSkeltalBoneData(action.name.Contains("Left") != handSwap, tempBoneTransforms);
                     }
                 }
             }

--- a/ControlWindowWPF/ControlWindowWPF/Globals.cs
+++ b/ControlWindowWPF/ControlWindowWPF/Globals.cs
@@ -113,7 +113,7 @@ namespace VirtualMotionCaptureControlPanel
             {
                 CurrentCommonSettingsWPF = Json.Serializer.Deserialize<CommonSettingsWPF>(File.ReadAllText(path)); //設定を読み込み
             }
-            catch (Exception e) {
+            catch (Exception) {
                 //エラー発生時は初期値にする
                 CurrentCommonSettingsWPF = new CommonSettingsWPF();
                 SaveCommonSettings();

--- a/ControlWindowWPF/ControlWindowWPF/MainWindow.xaml
+++ b/ControlWindowWPF/ControlWindowWPF/MainWindow.xaml
@@ -6,9 +6,9 @@
         xmlns:local="clr-namespace:VirtualMotionCaptureControlPanel"
         mc:Ignorable="d" Width="420" Height="210"
         Title="{DynamicResource MainWindowTitle}" FontSize="14" ResizeMode="CanMinimize" Background="#2A2A2A" Loaded="Window_Loaded" Closing="Window_Closing" Icon="Resources/VirtualMotionCapture_dark.ico">
-    <Grid>
-        <Button Visibility="Collapsed"/>
-        <!--This Button for fix style bug-->
+	<Grid>
+		<Button Visibility="Collapsed"/>
+		<!--This Button for fix style bug-->
 		<DockPanel LastChildFill="True">
 			<StatusBar MouseDoubleClick="StatusBar_MouseDoubleClick" DockPanel.Dock="Bottom" Margin="0,0,0,0" Height="25" Background="#2A2A2A">
 				<StatusBarItem>
@@ -17,25 +17,25 @@
 			</StatusBar>
 
 			<TabControl Margin="5,5,5,0">
-            <TabItem Header="{DynamicResource MainWindow_Setting}" ToolTip="{DynamicResource MainWindow_Setting_ToolTip}">
-                <UniformGrid Rows="2" Columns="3">
-                    <Button Content="{DynamicResource MainWindow_LoadSetting}" Name="LoadSettingsButton" Click="LoadSettingsButton_Click" ToolTip="{DynamicResource MainWindow_LoadSetting_ToolTip}"/>
-                    <Button Content="{DynamicResource MainWindow_ImportVRM}" Name="ImportVRMButton" Click="ImportVRMButton_Click" ToolTip="{DynamicResource MainWindow_ImportVRM_ToolTip}"/>
-                    <Button Content="{DynamicResource MainWindow_ShortcutKey}" Name="ShortcutKeyButton" Click="ShortcutKeyButton_Click" ToolTip="{DynamicResource MainWindow_ShortcutKey_ToolTip}"/>
-                    <Button Content="{DynamicResource MainWindow_SaveSetting}" Name="SaveSettingsButton" Click="SaveSettingsButton_Click" ToolTip="{DynamicResource MainWindow_SaveSetting_ToolTip}"/>
-                    <Button Content="{DynamicResource MainWindow_Calibration}" Name="CalibrationButton" Click="CalibrationButton_Click" ToolTip="{DynamicResource MainWindow_Calibration_ToolTip}"/>
-                    <Button Content="{DynamicResource MainWindow_AdvancedSetting}" Name="SettingButton" Click="SettingButton_Click" ToolTip="{DynamicResource MainWindow_AdvancedSetting_ToolTip}"/>
-                </UniformGrid>
-            </TabItem>
-            <TabItem Header="{DynamicResource MainWindow_Background}" ToolTip="{DynamicResource MainWindow_Background_ToolTip}">
-                <StackPanel Orientation="Vertical">
-                    <UniformGrid Rows="1" Columns="5">
-                        <Button Content="{DynamicResource MainWindow_GB}" Background="#00FF00" Foreground="Black" Name="ColorGreenButton" Click="ColorGreenButton_Click" ToolTip="{DynamicResource MainWindow_GB_ToolTip}"/>
-                        <Button Content="{DynamicResource MainWindow_BB}" Background="#0000FF" Foreground="White" Name="ColorBlueButton" Click="ColorBlueButton_Click" ToolTip="{DynamicResource MainWindow_BB_ToolTip}"/>
-                        <Button Content="{DynamicResource MainWindow_White240}" Background="#F0F0F0" Foreground="Black" Name="ColorWhiteButton" Click="ColorWhiteButton_Click" ToolTip="{DynamicResource MainWindow_White240_ToolTip}"/>
-                        <Button Content="{DynamicResource MainWindow_Custom}" Background="#AED4FF" Foreground="Black" Name="ColorCustomButton" Click="ColorCustomButton_Click" MouseRightButtonDown="ColorCustomButton_MouseRightButtonDown" ToolTip="{DynamicResource MainWindow_Custom_ToolTip}"/>
-                        <Button Content="{DynamicResource MainWindow_Transparent}" Name="ColorTransparentButton" Click="ColorTransparentButton_Click" ToolTip="{DynamicResource MainWindow_Transparent_ToolTip}"/>
-                    </UniformGrid>
+				<TabItem Header="{DynamicResource MainWindow_Setting}" ToolTip="{DynamicResource MainWindow_Setting_ToolTip}">
+					<UniformGrid Rows="2" Columns="3">
+						<Button Content="{DynamicResource MainWindow_LoadSetting}" Name="LoadSettingsButton" Click="LoadSettingsButton_Click" ToolTip="{DynamicResource MainWindow_LoadSetting_ToolTip}"/>
+						<Button Content="{DynamicResource MainWindow_ImportVRM}" Name="ImportVRMButton" Click="ImportVRMButton_Click" ToolTip="{DynamicResource MainWindow_ImportVRM_ToolTip}"/>
+						<Button Content="{DynamicResource MainWindow_ShortcutKey}" Name="ShortcutKeyButton" Click="ShortcutKeyButton_Click" ToolTip="{DynamicResource MainWindow_ShortcutKey_ToolTip}"/>
+						<Button Content="{DynamicResource MainWindow_SaveSetting}" Name="SaveSettingsButton" Click="SaveSettingsButton_Click" ToolTip="{DynamicResource MainWindow_SaveSetting_ToolTip}"/>
+						<Button Content="{DynamicResource MainWindow_Calibration}" Name="CalibrationButton" Click="CalibrationButton_Click" ToolTip="{DynamicResource MainWindow_Calibration_ToolTip}"/>
+						<Button Content="{DynamicResource MainWindow_AdvancedSetting}" Name="SettingButton" Click="SettingButton_Click" ToolTip="{DynamicResource MainWindow_AdvancedSetting_ToolTip}"/>
+					</UniformGrid>
+				</TabItem>
+				<TabItem Header="{DynamicResource MainWindow_Background}" ToolTip="{DynamicResource MainWindow_Background_ToolTip}">
+					<StackPanel Orientation="Vertical">
+						<UniformGrid Rows="1" Columns="5">
+							<Button Content="{DynamicResource MainWindow_GB}" Background="#00FF00" Foreground="Black" Name="ColorGreenButton" Click="ColorGreenButton_Click" ToolTip="{DynamicResource MainWindow_GB_ToolTip}"/>
+							<Button Content="{DynamicResource MainWindow_BB}" Background="#0000FF" Foreground="White" Name="ColorBlueButton" Click="ColorBlueButton_Click" ToolTip="{DynamicResource MainWindow_BB_ToolTip}"/>
+							<Button Content="{DynamicResource MainWindow_White240}" Background="#F0F0F0" Foreground="Black" Name="ColorWhiteButton" Click="ColorWhiteButton_Click" ToolTip="{DynamicResource MainWindow_White240_ToolTip}"/>
+							<Button Content="{DynamicResource MainWindow_Custom}" Background="#AED4FF" Foreground="Black" Name="ColorCustomButton" Click="ColorCustomButton_Click" MouseRightButtonDown="ColorCustomButton_MouseRightButtonDown" ToolTip="{DynamicResource MainWindow_Custom_ToolTip}"/>
+							<Button Content="{DynamicResource MainWindow_Transparent}" Name="ColorTransparentButton" Click="ColorTransparentButton_Click" ToolTip="{DynamicResource MainWindow_Transparent_ToolTip}"/>
+						</UniformGrid>
 						<Grid>
 							<Grid.ColumnDefinitions>
 								<ColumnDefinition />
@@ -49,147 +49,162 @@
 							<CheckBox Grid.Column="1" Grid.Row="0" VerticalAlignment="Stretch" HorizontalAlignment="Stretch" Margin="3" Content="{DynamicResource MainWindow_HideWindowBorder}" Name="WindowBorderCheckBox" Checked="WindowBorderCheckBox_Checked" Unchecked="WindowBorderCheckBox_Unchecked" ToolTip="{DynamicResource MainWindow_HideWindowBorder_ToolTip}"/>
 							<CheckBox Grid.Column="0" Grid.Row="1" VerticalAlignment="Stretch" HorizontalAlignment="Stretch" Margin="3" Content="{DynamicResource MainWindow_MouseInputPassThrough}" Name="WindowClickThroughCheckBox" Checked="WindowClickThroughCheckBox_Checked" Unchecked="WindowClickThroughCheckBox_Unchecked" ToolTip="{DynamicResource MainWindow_MouseInputPassThrough_ToolTip}"/>
 						</Grid>
-                </StackPanel>
-            </TabItem>
-            <TabItem Header="{DynamicResource MainWindow_Camera}">
-                <StackPanel Orientation="Vertical">
-                    <Grid>
-                        <Grid.RowDefinitions>
-                            <RowDefinition Height="Auto"/>
-                            <RowDefinition Height="Auto"/>
-                        </Grid.RowDefinitions>
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="*"/>
-                            <ColumnDefinition Width="*"/>
-                            <ColumnDefinition Width="*"/>
-                            <ColumnDefinition Width="Auto"/>
-                        </Grid.ColumnDefinitions>
-                        <Button Content="{DynamicResource MainWindow_Front}" Name="FrontCameraButton" Click="FrontCameraButton_Click" Grid.Row="0" Grid.Column="0"/>
-                        <Button Content="{DynamicResource MainWindow_Back}" Name="BackCameraButton" Click="BackCameraButton_Click" Grid.Row="0" Grid.Column="1"/>
-                        <Button Content="{DynamicResource MainWindow_Free}" Name="FreeCameraButton" Click="FreeCameraButton_Click" Grid.Row="0" Grid.Column="2"/>
-                        <Button Name="PhotoButton" Click="PhotoButton_Click" Grid.Row="0" Grid.Column="3">
-                            <Viewbox Width="30" Height="30">
-                                <Canvas Width="420" Height="420">
-                                    <Path Fill="#000000" Data="M406.8 96.4c-8.4-8.8-20-14-33.2-14h-66.4v-0.8c0-10-4-19.6-10.8-26c-6.8-6.8-16-10.8-26-10.8h-120     c-10.4 0-19.6 4-26.4 10.8c-6.8 6.8-10.8 16-10.8 26v0.8h-66c-13.2 0-24.8 5.2-33.2 14c-8.4 8.4-14 20.4-14 33.2v199.2     C0 342 5.2 353.6 14 362c8.4 8.4 20.4 14 33.2 14h326.4c13.2 0 24.8-5.2 33.2-14c8.4-8.4 14-20.4 14-33.2V129.6     C420.8 116.4 415.6 104.8 406.8 96.4z M400 328.8h-0.4c0 7.2-2.8 13.6-7.6 18.4s-11.2 7.6-18.4 7.6H47.2     c-7.2 0-13.6-2.8-18.4-7.6c-4.8-4.8-7.6-11.2-7.6-18.4V129.6c0-7.2 2.8-13.6 7.6-18.4s11.2-7.6 18.4-7.6h77.2     c6 0 10.8-4.8 10.8-10.8V81.2c0-4.4 1.6-8.4 4.4-11.2s6.8-4.4 11.2-4.4h119.6c4.4 0 8.4 1.6 11.2 4.4c2.8 2.8 4.4 6.8 4.4 11.2     v11.6c0 6 4.8 10.8 10.8 10.8H374c7.2 0 13.6 2.8 18.4 7.6s7.6 11.2 7.6 18.4V328.8z"/>
-                                    <Path Fill="#000000" Data="M210.4 130.8c-27.2 0-52 11.2-69.6 28.8c-18 18-28.8 42.4-28.8 69.6s11.2 52 28.8 69.6c18 18 42.4 28.8 69.6 28.8     s52-11.2 69.6-28.8c18-18 28.8-42.4 28.8-69.6s-11.2-52-28.8-69.6C262.4 142 237.6 130.8 210.4 130.8z M264.8 284     c-14 13.6-33.2 22.4-54.4 22.4S170 297.6 156 284c-14-14-22.4-33.2-22.4-54.4c0-21.2 8.8-40.4 22.4-54.4     c14-14 33.2-22.4 54.4-22.4s40.4 8.8 54.4 22.4c14 14 22.4 33.2 22.4 54.4C287.6 250.8 278.8 270 264.8 284z"/>
-                                    <Ellipse Canvas.Left="333.2" Canvas.Top="130.4" Width="39.2" Height="39.2" Fill="#000000"/>
-                                </Canvas>
-                            </Viewbox>
-                        </Button>
-                        <Button Content="{DynamicResource MainWindow_PositionFixed}" Name="PositionFixedCameraButton" Click="PositionFixedCameraButton_Click" Grid.Row="1" Grid.Column="0"/>
-                        <StackPanel Orientation="Vertical" VerticalAlignment="Bottom" Grid.Row="1" Grid.Column="1" Grid.ColumnSpan="3">
-                            <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" VerticalAlignment="Bottom">
-                                <CheckBox Content="{DynamicResource MainWindow_Mirror}" Name="CameraMirrorCheckBox" Checked="CameraMirrorCheckBox_Checked" Unchecked="CameraMirrorCheckBox_Unchecked"/>
-                                <CheckBox Content="{DynamicResource MainWindow_ShowGrid}" Name="CameraGridCheckBox" Checked="CameraGridCheckBox_Checked" Unchecked="CameraGridCheckBox_Unchecked"/>
-                            </StackPanel>
-                            <DockPanel>
-                                <TextBlock Text="FOV" DockPanel.Dock="Left"/>
-                                <TextBlock Text="60" DockPanel.Dock="Right" Width="30" Name="FOVTextBlock"/>
-                                <Slider Name="FOVSlider" Grid.Row="1" Grid.Column="1" Minimum="1" Value="60" Maximum="179" SmallChange="1" TickFrequency="1" IsSnapToTickEnabled="True" ValueChanged="FOVSlider_ValueChanged"/>
-                            </DockPanel>
-                        </StackPanel>
-                    </Grid>
-                    <StackPanel Orientation="Horizontal">
-                        <TextBlock Text="{DynamicResource MainWindow_CameraDescription}" Margin="0,-3,0,0"/>
-                    </StackPanel>
-                </StackPanel>
-            </TabItem>
-            <TabItem ToolTip="{DynamicResource MainWindow_LipSync_ToolTip}">
-                <TabItem.Header>
-                    <TextBlock Text="{DynamicResource MainWindow_LipSync}" Name="LipsyncTabTextBlock" Background="PaleVioletRed"/>
-                </TabItem.Header>
-                <StackPanel Orientation="Vertical">
-                    <StackPanel Orientation="Horizontal" Margin="0,0,0,5">
-                        <CheckBox Content="{DynamicResource MainWindow_EnableLipSync}" Name="LipSyncCheckBox" Checked="LipSyncCheckBox_Checked" Unchecked="LipSyncCheckBox_Unchecked" ToolTip="{DynamicResource MainWindow_EnableLipSync_ToolTip}"/>
-                        <CheckBox Content="{DynamicResource MainWindow_MaxWeight}" Name="MaxWeightCheckBox" Checked="MaxWeightCheckBox_Checked" Unchecked="MaxWeightCheckBox_Unchecked" ToolTip="{DynamicResource MainWindow_MaxWeight_ToolTip}"/>
-                        <CheckBox Content="{DynamicResource MainWindow_MaxWeightEmphasis}" Name="MaxWeightEmphasisCheckBox" Checked="MaxWeightEmphasisCheckBox_Checked" Unchecked="MaxWeightEmphasisCheckBox_Unchecked" ToolTip="{DynamicResource MainWindow_MaxWeightEmphasis_ToolTip}"/>
-                    </StackPanel>
-                    <Grid>
-                        <Grid.RowDefinitions>
-                            <RowDefinition />
-                            <RowDefinition />
-                            <RowDefinition />
-                        </Grid.RowDefinitions>
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="Auto"/>
-                            <ColumnDefinition />
-                            <ColumnDefinition Width="Auto"/>
-                        </Grid.ColumnDefinitions>
-                        <TextBlock Text="{DynamicResource MainWindow_Device}" Grid.Row="0" Grid.Column="0"/>
+					</StackPanel>
+				</TabItem>
+				<TabItem Header="{DynamicResource MainWindow_Camera}">
+					<StackPanel Orientation="Vertical">
+						<Grid>
+							<Grid.RowDefinitions>
+								<RowDefinition Height="Auto"/>
+								<RowDefinition Height="Auto"/>
+							</Grid.RowDefinitions>
+							<Grid.ColumnDefinitions>
+								<ColumnDefinition Width="*"/>
+								<ColumnDefinition Width="*"/>
+								<ColumnDefinition Width="*"/>
+								<ColumnDefinition Width="Auto"/>
+							</Grid.ColumnDefinitions>
+							<Button Content="{DynamicResource MainWindow_Front}" Name="FrontCameraButton" Click="FrontCameraButton_Click" Grid.Row="0" Grid.Column="0"/>
+							<Button Content="{DynamicResource MainWindow_Back}" Name="BackCameraButton" Click="BackCameraButton_Click" Grid.Row="0" Grid.Column="1"/>
+							<Button Content="{DynamicResource MainWindow_Free}" Name="FreeCameraButton" Click="FreeCameraButton_Click" Grid.Row="0" Grid.Column="2"/>
+							<Button Name="PhotoButton" Click="PhotoButton_Click" Grid.Row="0" Grid.Column="3">
+								<Viewbox Width="30" Height="30">
+									<Canvas Width="420" Height="420">
+										<Path Fill="#000000" Data="M406.8 96.4c-8.4-8.8-20-14-33.2-14h-66.4v-0.8c0-10-4-19.6-10.8-26c-6.8-6.8-16-10.8-26-10.8h-120     c-10.4 0-19.6 4-26.4 10.8c-6.8 6.8-10.8 16-10.8 26v0.8h-66c-13.2 0-24.8 5.2-33.2 14c-8.4 8.4-14 20.4-14 33.2v199.2     C0 342 5.2 353.6 14 362c8.4 8.4 20.4 14 33.2 14h326.4c13.2 0 24.8-5.2 33.2-14c8.4-8.4 14-20.4 14-33.2V129.6     C420.8 116.4 415.6 104.8 406.8 96.4z M400 328.8h-0.4c0 7.2-2.8 13.6-7.6 18.4s-11.2 7.6-18.4 7.6H47.2     c-7.2 0-13.6-2.8-18.4-7.6c-4.8-4.8-7.6-11.2-7.6-18.4V129.6c0-7.2 2.8-13.6 7.6-18.4s11.2-7.6 18.4-7.6h77.2     c6 0 10.8-4.8 10.8-10.8V81.2c0-4.4 1.6-8.4 4.4-11.2s6.8-4.4 11.2-4.4h119.6c4.4 0 8.4 1.6 11.2 4.4c2.8 2.8 4.4 6.8 4.4 11.2     v11.6c0 6 4.8 10.8 10.8 10.8H374c7.2 0 13.6 2.8 18.4 7.6s7.6 11.2 7.6 18.4V328.8z"/>
+										<Path Fill="#000000" Data="M210.4 130.8c-27.2 0-52 11.2-69.6 28.8c-18 18-28.8 42.4-28.8 69.6s11.2 52 28.8 69.6c18 18 42.4 28.8 69.6 28.8     s52-11.2 69.6-28.8c18-18 28.8-42.4 28.8-69.6s-11.2-52-28.8-69.6C262.4 142 237.6 130.8 210.4 130.8z M264.8 284     c-14 13.6-33.2 22.4-54.4 22.4S170 297.6 156 284c-14-14-22.4-33.2-22.4-54.4c0-21.2 8.8-40.4 22.4-54.4     c14-14 33.2-22.4 54.4-22.4s40.4 8.8 54.4 22.4c14 14 22.4 33.2 22.4 54.4C287.6 250.8 278.8 270 264.8 284z"/>
+										<Ellipse Canvas.Left="333.2" Canvas.Top="130.4" Width="39.2" Height="39.2" Fill="#000000"/>
+									</Canvas>
+								</Viewbox>
+							</Button>
+							<Button Content="{DynamicResource MainWindow_PositionFixed}" Name="PositionFixedCameraButton" Click="PositionFixedCameraButton_Click" Grid.Row="1" Grid.Column="0"/>
+							<StackPanel Orientation="Vertical" VerticalAlignment="Bottom" Grid.Row="1" Grid.Column="1" Grid.ColumnSpan="3">
+								<StackPanel Orientation="Horizontal" HorizontalAlignment="Right" VerticalAlignment="Bottom">
+									<CheckBox Content="{DynamicResource MainWindow_Mirror}" Name="CameraMirrorCheckBox" Checked="CameraMirrorCheckBox_Checked" Unchecked="CameraMirrorCheckBox_Unchecked"/>
+									<CheckBox Content="{DynamicResource MainWindow_ShowGrid}" Name="CameraGridCheckBox" Checked="CameraGridCheckBox_Checked" Unchecked="CameraGridCheckBox_Unchecked"/>
+								</StackPanel>
+								<DockPanel>
+									<TextBlock Text="FOV" DockPanel.Dock="Left"/>
+									<TextBlock Text="60" DockPanel.Dock="Right" Width="30" Name="FOVTextBlock"/>
+									<Slider Name="FOVSlider" Grid.Row="1" Grid.Column="1" Minimum="1" Value="60" Maximum="179" SmallChange="1" TickFrequency="1" IsSnapToTickEnabled="True" ValueChanged="FOVSlider_ValueChanged"/>
+								</DockPanel>
+							</StackPanel>
+						</Grid>
+						<StackPanel Orientation="Horizontal">
+							<TextBlock Text="{DynamicResource MainWindow_CameraDescription}" Margin="0,-3,0,0"/>
+						</StackPanel>
+					</StackPanel>
+				</TabItem>
+				<TabItem ToolTip="{DynamicResource MainWindow_LipSync_ToolTip}">
+					<TabItem.Header>
+						<TextBlock Text="{DynamicResource MainWindow_LipSync}" Name="LipsyncTabTextBlock" Background="PaleVioletRed"/>
+					</TabItem.Header>
+					<StackPanel Orientation="Vertical">
+						<StackPanel Orientation="Horizontal" Margin="0,0,0,5">
+							<CheckBox Content="{DynamicResource MainWindow_EnableLipSync}" Name="LipSyncCheckBox" Checked="LipSyncCheckBox_Checked" Unchecked="LipSyncCheckBox_Unchecked" ToolTip="{DynamicResource MainWindow_EnableLipSync_ToolTip}"/>
+							<CheckBox Content="{DynamicResource MainWindow_MaxWeight}" Name="MaxWeightCheckBox" Checked="MaxWeightCheckBox_Checked" Unchecked="MaxWeightCheckBox_Unchecked" ToolTip="{DynamicResource MainWindow_MaxWeight_ToolTip}"/>
+							<CheckBox Content="{DynamicResource MainWindow_MaxWeightEmphasis}" Name="MaxWeightEmphasisCheckBox" Checked="MaxWeightEmphasisCheckBox_Checked" Unchecked="MaxWeightEmphasisCheckBox_Unchecked" ToolTip="{DynamicResource MainWindow_MaxWeightEmphasis_ToolTip}"/>
+						</StackPanel>
+						<Grid>
+							<Grid.RowDefinitions>
+								<RowDefinition />
+								<RowDefinition />
+								<RowDefinition />
+							</Grid.RowDefinitions>
+							<Grid.ColumnDefinitions>
+								<ColumnDefinition Width="Auto"/>
+								<ColumnDefinition />
+								<ColumnDefinition Width="Auto"/>
+							</Grid.ColumnDefinitions>
+							<TextBlock Text="{DynamicResource MainWindow_Device}" Grid.Row="0" Grid.Column="0"/>
 							<ComboBox Name="LipSyncDeviceComboBox" Grid.Row="0" Grid.Column="1" Margin="10,0,0,0" SelectionChanged="LipSyncDeviceComboBox_SelectionChanged" ToolTip="{DynamicResource MainWindow_Device_ToolTip}"/>
-                        <Button Content="{DynamicResource MainWindow_DeviceRefresh}" Margin="2" Height="20" Name="LipSyncDeviceRefreshButton" Grid.Row="0" Grid.Column="2" Click="LipSyncDeviceRefreshButton_Click" ToolTip="{DynamicResource MainWindow_DeviceRefresh_ToolTip}"/>
-                        <TextBlock Text="{DynamicResource MainWindow_Gain}" Grid.Row="1" Grid.Column="0"/>
-                        <Slider Name="GainSlider" Grid.Row="1" Grid.Column="1" Minimum="10" Value="10" Maximum="2560" SmallChange="1" ValueChanged="GainSlider_ValueChanged" ToolTip="{DynamicResource MainWindow_Gain_ToolTip}"/>
-                        <TextBlock Text="1.0" Name="GainTextBlock" Grid.Row="1" Grid.Column="2" TextAlignment="Center"/>
-                        <TextBlock Text="{DynamicResource MainWindow_WeightThreashold}" Grid.Row="2" Grid.Column="0"/>
-                        <Slider Name="WeightThreasholdSlider" Grid.Row="2" Grid.Column="1" Minimum="0" Value="0" Maximum="100" SmallChange="1" ValueChanged="WeightThreasholdSlider_ValueChanged" ToolTip="{DynamicResource MainWindow_WeightThreashold_ToolTip}"/>
-                        <TextBlock Text="0.00" Name="WeightThreasholdTextBlock" Grid.Row="2" Grid.Column="2" TextAlignment="Center"/>
+							<Button Content="{DynamicResource MainWindow_DeviceRefresh}" Margin="2" Height="20" Name="LipSyncDeviceRefreshButton" Grid.Row="0" Grid.Column="2" Click="LipSyncDeviceRefreshButton_Click" ToolTip="{DynamicResource MainWindow_DeviceRefresh_ToolTip}"/>
+							<TextBlock Text="{DynamicResource MainWindow_Gain}" Grid.Row="1" Grid.Column="0"/>
+							<Slider Name="GainSlider" Grid.Row="1" Grid.Column="1" Minimum="10" Value="10" Maximum="2560" SmallChange="1" ValueChanged="GainSlider_ValueChanged" ToolTip="{DynamicResource MainWindow_Gain_ToolTip}"/>
+							<TextBlock Text="1.0" Name="GainTextBlock" Grid.Row="1" Grid.Column="2" TextAlignment="Center"/>
+							<TextBlock Text="{DynamicResource MainWindow_WeightThreashold}" Grid.Row="2" Grid.Column="0"/>
+							<Slider Name="WeightThreasholdSlider" Grid.Row="2" Grid.Column="1" Minimum="0" Value="0" Maximum="100" SmallChange="1" ValueChanged="WeightThreasholdSlider_ValueChanged" ToolTip="{DynamicResource MainWindow_WeightThreashold_ToolTip}"/>
+							<TextBlock Text="0.00" Name="WeightThreasholdTextBlock" Grid.Row="2" Grid.Column="2" TextAlignment="Center"/>
 
-                    </Grid>
-                </StackPanel>
-            </TabItem>
-            <TabItem Header="{DynamicResource MainWindow_Face}" ToolTip="{DynamicResource MainWindow_Face_ToolTip}">
-                <StackPanel Orientation="Vertical">
-                    <DockPanel Margin="0">
-                        <CheckBox Content="{DynamicResource MainWindow_AutoBlink}" Margin="0" Name="AutoBlinkCheckBox" Checked="AutoBlinkCheckBox_Checked" Unchecked="AutoBlinkCheckBox_Unchecked" ToolTip="{DynamicResource MainWindow_AutoBlink_ToolTip}"/>
-                        <ComboBox Name="DefaultFaceComboBox" DockPanel.Dock="Right" Width="110" SelectionChanged="DefaultFaceComboBox_SelectionChanged" ToolTip="{DynamicResource MainWindow_DefaultFace_ToolTip}"/>
-                        <TextBlock Text="{DynamicResource MainWindow_DefaultFace}" VerticalAlignment="Center" DockPanel.Dock="Right" TextAlignment="Right"/>
-                    </DockPanel>
-                    <Grid>
-                        <Grid.RowDefinitions>
-                            <RowDefinition />
-                            <RowDefinition />
-                            <RowDefinition />
-                            <RowDefinition />
-                        </Grid.RowDefinitions>
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="Auto"/>
-                            <ColumnDefinition />
-                            <ColumnDefinition Width="Auto"/>
-                            <ColumnDefinition Width="Auto"/>
-                            <ColumnDefinition />
-                            <ColumnDefinition Width="Auto"/>
-                        </Grid.ColumnDefinitions>
-                        <TextBlock Text="{DynamicResource MainWindow_TimeToNextBlink}" Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="3"/>
-                        <TextBlock Text="{DynamicResource MainWindow_MinTime}" Grid.Row="1" Grid.Column="0"/>
-                        <Slider Name="BlinkTimeMinSlider" Grid.Row="1" Grid.Column="1" Minimum="0" Value="10" Maximum="6000" ValueChanged="BlinkTimeMinSlider_ValueChanged" SmallChange="1" ToolTip="{DynamicResource MainWindow_MinTime_ToolTip}"/>
-                        <TextBlock Text="1.0" Name="BlinkTimeMinTextBlock" Grid.Row="1" Grid.Column="2" TextAlignment="Center"/>
-                        <TextBlock Text="{DynamicResource MainWindow_MaxTime}" Grid.Row="2" Grid.Column="0"/>
-                        <Slider Name="BlinkTimeMaxSlider" Grid.Row="2" Grid.Column="1" Minimum="0" Value="100" Maximum="6000" ValueChanged="BlinkTimeMaxSlider_ValueChanged" SmallChange="1" ToolTip="{DynamicResource MainWindow_MaxTime_ToolTip}"/>
-                        <TextBlock Text="10.0" Name="BlinkTimeMaxTextBlock" Grid.Row="2" Grid.Column="2" TextAlignment="Center"/>
+						</Grid>
+					</StackPanel>
+				</TabItem>
+				<TabItem Header="{DynamicResource MainWindow_Face}" ToolTip="{DynamicResource MainWindow_Face_ToolTip}">
+					<StackPanel Orientation="Vertical">
+						<DockPanel Margin="0">
+							<CheckBox Content="{DynamicResource MainWindow_AutoBlink}" Margin="0" Name="AutoBlinkCheckBox" Checked="AutoBlinkCheckBox_Checked" Unchecked="AutoBlinkCheckBox_Unchecked" ToolTip="{DynamicResource MainWindow_AutoBlink_ToolTip}"/>
+							<ComboBox Name="DefaultFaceComboBox" DockPanel.Dock="Right" Width="110" SelectionChanged="DefaultFaceComboBox_SelectionChanged" ToolTip="{DynamicResource MainWindow_DefaultFace_ToolTip}"/>
+							<TextBlock Text="{DynamicResource MainWindow_DefaultFace}" VerticalAlignment="Center" DockPanel.Dock="Right" TextAlignment="Right"/>
+						</DockPanel>
+						<Grid>
+							<Grid.RowDefinitions>
+								<RowDefinition />
+								<RowDefinition />
+								<RowDefinition />
+								<RowDefinition />
+							</Grid.RowDefinitions>
+							<Grid.ColumnDefinitions>
+								<ColumnDefinition Width="Auto"/>
+								<ColumnDefinition />
+								<ColumnDefinition Width="Auto"/>
+								<ColumnDefinition Width="Auto"/>
+								<ColumnDefinition />
+								<ColumnDefinition Width="Auto"/>
+							</Grid.ColumnDefinitions>
+							<TextBlock Text="{DynamicResource MainWindow_TimeToNextBlink}" Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="3"/>
+							<TextBlock Text="{DynamicResource MainWindow_MinTime}" Grid.Row="1" Grid.Column="0"/>
+							<Slider Name="BlinkTimeMinSlider" Grid.Row="1" Grid.Column="1" Minimum="0" Value="10" Maximum="6000" ValueChanged="BlinkTimeMinSlider_ValueChanged" SmallChange="1" ToolTip="{DynamicResource MainWindow_MinTime_ToolTip}"/>
+							<TextBlock Text="1.0" Name="BlinkTimeMinTextBlock" Grid.Row="1" Grid.Column="2" TextAlignment="Center"/>
+							<TextBlock Text="{DynamicResource MainWindow_MaxTime}" Grid.Row="2" Grid.Column="0"/>
+							<Slider Name="BlinkTimeMaxSlider" Grid.Row="2" Grid.Column="1" Minimum="0" Value="100" Maximum="6000" ValueChanged="BlinkTimeMaxSlider_ValueChanged" SmallChange="1" ToolTip="{DynamicResource MainWindow_MaxTime_ToolTip}"/>
+							<TextBlock Text="10.0" Name="BlinkTimeMaxTextBlock" Grid.Row="2" Grid.Column="2" TextAlignment="Center"/>
 
-                        <TextBlock Text="{DynamicResource MainWindow_AnimationTime}" Grid.Row="0" Grid.Column="3" Grid.ColumnSpan="3"/>
-                        <TextBlock Text="{DynamicResource MainWindow_TimeToClose}" Grid.Row="1" Grid.Column="3" Margin="5,0,0,0"/>
-                        <Slider Name="CloseAnimationTimeSlider" Grid.Row="1" Grid.Column="4" Minimum="0" Value="6" Maximum="200" ValueChanged="CloseAnimationTimeSlider_ValueChanged" SmallChange="1" ToolTip="{DynamicResource MainWindow_TimeToClose_ToolTip}"/>
-                        <TextBlock Text="0.06" Name="CloseAnimationTimeTextBlock" Grid.Row="1" Grid.Column="5" TextAlignment="Center"/>
-                        <TextBlock Text="{DynamicResource MainWindow_TimeToOpen}" Grid.Row="2" Grid.Column="3" Margin="5,0,0,0"/>
-                        <Slider Name="OpenAnimationTimeSlider" Grid.Row="2" Grid.Column="4" Minimum="0" Value="3" Maximum="200" ValueChanged="OpenAnimationTimeSlider_ValueChanged" SmallChange="1" ToolTip="{DynamicResource MainWindow_TimeToOpen_ToolTip}"/>
-                        <TextBlock Text="0.03" Name="OpenAnimationTimeTextBlock" Grid.Row="2" Grid.Column="5" TextAlignment="Center"/>
-                        <TextBlock Text="{DynamicResource MainWindow_ClosedTime}" Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="4" HorizontalAlignment="Right"/>
-                        <Slider Name="ClosingTimeSlider" Grid.Row="3" Grid.Column="4" Minimum="0" Value="3" Maximum="200" ValueChanged="ClosingTimeSlider_ValueChanged" SmallChange="1" ToolTip="{DynamicResource MainWindow_ClosedTime_ToolTip}"/>
-                        <TextBlock Text="0.10" Name="ClosingTimeTextBlock" Grid.Row="3" Grid.Column="5" TextAlignment="Center"/>
-                    </Grid>
-                </StackPanel>
-            </TabItem>
-            <TabItem Header="{DynamicResource MainWindow_Appearance}">
-                <DockPanel>
-                    <Button Content="{DynamicResource MainWindow_LightColor}" Name="LightColorButton" Click="LightColorButton_Click" DockPanel.Dock="Right" VerticalAlignment="Top"/>
-                    <GroupBox DockPanel.Dock="Top" Header="{DynamicResource MainWindow_LightAngle}">
-                        <StackPanel Orientation="Vertical">
-                            <DockPanel DockPanel.Dock="Top">
-                                <TextBlock Text="{DynamicResource MainWindow_LightVerticalDirection}"/>
-                                <Slider Name="LightXSlider" Minimum="0" Value="130" Maximum="359" ValueChanged="LightSlider_ValueChanged" SmallChange="1"/>
-                            </DockPanel>
-                            <DockPanel DockPanel.Dock="Top">
-                                <TextBlock Text="{DynamicResource MainWindow_LightHorizontalDirection}"/>
-                                <Slider Name="LightYSlider" Minimum="0" Value="43" Maximum="359" ValueChanged="LightSlider_ValueChanged" SmallChange="1" DockPanel.Dock="Top"/>
-                            </DockPanel>
-                        </StackPanel>
-                    </GroupBox>
-                    <Grid/>
-                </DockPanel>
-            </TabItem>
-        </TabControl>
+							<TextBlock Text="{DynamicResource MainWindow_AnimationTime}" Grid.Row="0" Grid.Column="3" Grid.ColumnSpan="3"/>
+							<TextBlock Text="{DynamicResource MainWindow_TimeToClose}" Grid.Row="1" Grid.Column="3" Margin="5,0,0,0"/>
+							<Slider Name="CloseAnimationTimeSlider" Grid.Row="1" Grid.Column="4" Minimum="0" Value="6" Maximum="200" ValueChanged="CloseAnimationTimeSlider_ValueChanged" SmallChange="1" ToolTip="{DynamicResource MainWindow_TimeToClose_ToolTip}"/>
+							<TextBlock Text="0.06" Name="CloseAnimationTimeTextBlock" Grid.Row="1" Grid.Column="5" TextAlignment="Center"/>
+							<TextBlock Text="{DynamicResource MainWindow_TimeToOpen}" Grid.Row="2" Grid.Column="3" Margin="5,0,0,0"/>
+							<Slider Name="OpenAnimationTimeSlider" Grid.Row="2" Grid.Column="4" Minimum="0" Value="3" Maximum="200" ValueChanged="OpenAnimationTimeSlider_ValueChanged" SmallChange="1" ToolTip="{DynamicResource MainWindow_TimeToOpen_ToolTip}"/>
+							<TextBlock Text="0.03" Name="OpenAnimationTimeTextBlock" Grid.Row="2" Grid.Column="5" TextAlignment="Center"/>
+							<TextBlock Text="{DynamicResource MainWindow_ClosedTime}" Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="4" HorizontalAlignment="Right"/>
+							<Slider Name="ClosingTimeSlider" Grid.Row="3" Grid.Column="4" Minimum="0" Value="3" Maximum="200" ValueChanged="ClosingTimeSlider_ValueChanged" SmallChange="1" ToolTip="{DynamicResource MainWindow_ClosedTime_ToolTip}"/>
+							<TextBlock Text="0.10" Name="ClosingTimeTextBlock" Grid.Row="3" Grid.Column="5" TextAlignment="Center"/>
+						</Grid>
+					</StackPanel>
+				</TabItem>
+				<TabItem Header="{DynamicResource MainWindow_Appearance}">
+					<DockPanel>
+						<Button Content="{DynamicResource MainWindow_LightColor}" Name="LightColorButton" Click="LightColorButton_Click" DockPanel.Dock="Right" VerticalAlignment="Top"/>
+						<GroupBox DockPanel.Dock="Top" Header="{DynamicResource MainWindow_LightAngle}">
+							<StackPanel Orientation="Vertical">
+								<DockPanel DockPanel.Dock="Top">
+									<TextBlock Text="{DynamicResource MainWindow_LightVerticalDirection}"/>
+									<Slider Name="LightXSlider" Minimum="0" Value="130" Maximum="359" ValueChanged="LightSlider_ValueChanged" SmallChange="1"/>
+								</DockPanel>
+								<DockPanel DockPanel.Dock="Top">
+									<TextBlock Text="{DynamicResource MainWindow_LightHorizontalDirection}"/>
+									<Slider Name="LightYSlider" Minimum="0" Value="43" Maximum="359" ValueChanged="LightSlider_ValueChanged" SmallChange="1" DockPanel.Dock="Top"/>
+								</DockPanel>
+							</StackPanel>
+						</GroupBox>
+						<Grid/>
+					</DockPanel>
+				</TabItem>
+				<TabItem Header="ヘルプ">
+					<StackPanel Orientation="Vertical">
+						<GroupBox Header="使い方などはWebサイトをご覧ください">
+							<StackPanel Orientation="Vertical" DockPanel.Dock="Top">
+								<TextBlock><Hyperlink NavigateUri="https://sh-akira.github.io/VirtualMotionCapture/manual/" RequestNavigate="Hyperlink_RequestNavigate">説明書</Hyperlink></TextBlock>
+								<TextBlock><Hyperlink NavigateUri="https://github.com/sh-akira/VirtualMotionCapture/wiki/%E3%82%88%E3%81%8F%E3%81%82%E3%82%8B%E8%B3%AA%E5%95%8F%E3%81%A8%E5%9B%9E%E7%AD%94" RequestNavigate="Hyperlink_RequestNavigate">よくある質問と回答</Hyperlink></TextBlock>
+							</StackPanel>
+						</GroupBox>
+						<GroupBox Header="エラーが出たときは">
+							<StackPanel Orientation="Vertical" DockPanel.Dock="Top">
+								<TextBlock Text="↓をダブルクリックでクリップボードにコピーされます。" TextWrapping="Wrap"/>
+							</StackPanel>
+						</GroupBox>
+					</StackPanel>
+				</TabItem>
+			</TabControl>
 		</DockPanel>
 	</Grid>
 </Window>

--- a/ControlWindowWPF/ControlWindowWPF/MainWindow.xaml
+++ b/ControlWindowWPF/ControlWindowWPF/MainWindow.xaml
@@ -4,12 +4,19 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:VirtualMotionCaptureControlPanel"
-        mc:Ignorable="d" Width="420" Height="185"
+        mc:Ignorable="d" Width="420" Height="210"
         Title="{DynamicResource MainWindowTitle}" FontSize="14" ResizeMode="CanMinimize" Background="#2A2A2A" Loaded="Window_Loaded" Closing="Window_Closing" Icon="Resources/VirtualMotionCapture_dark.ico">
     <Grid>
         <Button Visibility="Collapsed"/>
         <!--This Button for fix style bug-->
-        <TabControl Margin="5">
+		<DockPanel LastChildFill="True">
+			<StatusBar MouseDoubleClick="StatusBar_MouseDoubleClick" DockPanel.Dock="Bottom" Margin="0,0,0,0" Height="25" Background="#2A2A2A">
+				<StatusBarItem>
+					<TextBlock Name="UnityLogStatusTextBlock" FontSize="12" Foreground="#EEEEEE">Welcome to Virtual Motion Capture</TextBlock>
+				</StatusBarItem>
+			</StatusBar>
+
+			<TabControl Margin="5,5,5,0">
             <TabItem Header="{DynamicResource MainWindow_Setting}" ToolTip="{DynamicResource MainWindow_Setting_ToolTip}">
                 <UniformGrid Rows="2" Columns="3">
                     <Button Content="{DynamicResource MainWindow_LoadSetting}" Name="LoadSettingsButton" Click="LoadSettingsButton_Click" ToolTip="{DynamicResource MainWindow_LoadSetting_ToolTip}"/>
@@ -29,13 +36,19 @@
                         <Button Content="{DynamicResource MainWindow_Custom}" Background="#AED4FF" Foreground="Black" Name="ColorCustomButton" Click="ColorCustomButton_Click" MouseRightButtonDown="ColorCustomButton_MouseRightButtonDown" ToolTip="{DynamicResource MainWindow_Custom_ToolTip}"/>
                         <Button Content="{DynamicResource MainWindow_Transparent}" Name="ColorTransparentButton" Click="ColorTransparentButton_Click" ToolTip="{DynamicResource MainWindow_Transparent_ToolTip}"/>
                     </UniformGrid>
-                    <StackPanel Orientation="Horizontal">
-                        <CheckBox Content="{DynamicResource MainWindow_WindowAlwaysTopMost}" Name="TopMostCheckBox" Checked="TopMostCheckBox_Checked" Unchecked="TopMostCheckBox_Unchecked" ToolTip="{DynamicResource MainWindow_WindowAlwaysTopMost_ToolTip}"/>
-                        <CheckBox Content="{DynamicResource MainWindow_HideWindowBorder}" Name="WindowBorderCheckBox" Checked="WindowBorderCheckBox_Checked" Unchecked="WindowBorderCheckBox_Unchecked" ToolTip="{DynamicResource MainWindow_HideWindowBorder_ToolTip}"/>
-                    </StackPanel>
-                    <StackPanel Orientation="Horizontal">
-                        <CheckBox Content="{DynamicResource MainWindow_MouseInputPassThrough}" Name="WindowClickThroughCheckBox" Checked="WindowClickThroughCheckBox_Checked" Unchecked="WindowClickThroughCheckBox_Unchecked" ToolTip="{DynamicResource MainWindow_MouseInputPassThrough_ToolTip}"/>
-                    </StackPanel>
+						<Grid>
+							<Grid.ColumnDefinitions>
+								<ColumnDefinition />
+								<ColumnDefinition />
+							</Grid.ColumnDefinitions>
+							<Grid.RowDefinitions>
+								<RowDefinition />
+								<RowDefinition />
+							</Grid.RowDefinitions>
+							<CheckBox Grid.Column="0" Grid.Row="0" VerticalAlignment="Stretch" HorizontalAlignment="Stretch" Margin="3" Content="{DynamicResource MainWindow_WindowAlwaysTopMost}" Name="TopMostCheckBox" Checked="TopMostCheckBox_Checked" Unchecked="TopMostCheckBox_Unchecked" ToolTip="{DynamicResource MainWindow_WindowAlwaysTopMost_ToolTip}"/>
+							<CheckBox Grid.Column="1" Grid.Row="0" VerticalAlignment="Stretch" HorizontalAlignment="Stretch" Margin="3" Content="{DynamicResource MainWindow_HideWindowBorder}" Name="WindowBorderCheckBox" Checked="WindowBorderCheckBox_Checked" Unchecked="WindowBorderCheckBox_Unchecked" ToolTip="{DynamicResource MainWindow_HideWindowBorder_ToolTip}"/>
+							<CheckBox Grid.Column="0" Grid.Row="1" VerticalAlignment="Stretch" HorizontalAlignment="Stretch" Margin="3" Content="{DynamicResource MainWindow_MouseInputPassThrough}" Name="WindowClickThroughCheckBox" Checked="WindowClickThroughCheckBox_Checked" Unchecked="WindowClickThroughCheckBox_Unchecked" ToolTip="{DynamicResource MainWindow_MouseInputPassThrough_ToolTip}"/>
+						</Grid>
                 </StackPanel>
             </TabItem>
             <TabItem Header="{DynamicResource MainWindow_Camera}">
@@ -103,7 +116,7 @@
                             <ColumnDefinition Width="Auto"/>
                         </Grid.ColumnDefinitions>
                         <TextBlock Text="{DynamicResource MainWindow_Device}" Grid.Row="0" Grid.Column="0"/>
-                        <ComboBox Name="LipSyncDeviceComboBox" Grid.Row="0" Grid.Column="1" SelectionChanged="LipSyncDeviceComboBox_SelectionChanged" ToolTip="{DynamicResource MainWindow_Device_ToolTip}"/>
+							<ComboBox Name="LipSyncDeviceComboBox" Grid.Row="0" Grid.Column="1" Margin="10,0,0,0" SelectionChanged="LipSyncDeviceComboBox_SelectionChanged" ToolTip="{DynamicResource MainWindow_Device_ToolTip}"/>
                         <Button Content="{DynamicResource MainWindow_DeviceRefresh}" Margin="2" Height="20" Name="LipSyncDeviceRefreshButton" Grid.Row="0" Grid.Column="2" Click="LipSyncDeviceRefreshButton_Click" ToolTip="{DynamicResource MainWindow_DeviceRefresh_ToolTip}"/>
                         <TextBlock Text="{DynamicResource MainWindow_Gain}" Grid.Row="1" Grid.Column="0"/>
                         <Slider Name="GainSlider" Grid.Row="1" Grid.Column="1" Minimum="10" Value="10" Maximum="2560" SmallChange="1" ValueChanged="GainSlider_ValueChanged" ToolTip="{DynamicResource MainWindow_Gain_ToolTip}"/>
@@ -177,5 +190,6 @@
                 </DockPanel>
             </TabItem>
         </TabControl>
-    </Grid>
+		</DockPanel>
+	</Grid>
 </Window>

--- a/ControlWindowWPF/ControlWindowWPF/MainWindow.xaml.cs
+++ b/ControlWindowWPF/ControlWindowWPF/MainWindow.xaml.cs
@@ -313,6 +313,21 @@ namespace VirtualMotionCaptureControlPanel
                 else if (e.CommandType == typeof(PipeCommands.LogNotify))
                 {
                     var d = (PipeCommands.LogNotify)e.Data;
+
+                    switch (d.type) {
+                        case NotifyLogTypes.Error:
+                        case NotifyLogTypes.Assert:
+                        case NotifyLogTypes.Exception:
+                            UnityLogStatusTextBlock.Foreground = new SolidColorBrush(Color.FromRgb(255, 102, 102));
+                            break;
+                        case NotifyLogTypes.Warning:
+                            UnityLogStatusTextBlock.Foreground = new SolidColorBrush(Color.FromRgb(255, 255, 0));
+                            break;
+                        default:
+                            UnityLogStatusTextBlock.Foreground = new SolidColorBrush(Color.FromRgb(238, 238, 238));
+                            break;
+                    }
+
                     UnityLogStatusTextBlock.Text = "["+d.type.ToString()+"] "+d.condition;
                     lastLog = d;
                 }
@@ -707,6 +722,11 @@ namespace VirtualMotionCaptureControlPanel
                 Clipboard.SetText(trace);
                 MessageBox.Show("Trace log has copied.", "Trace log", MessageBoxButton.OK, MessageBoxImage.Information);
             }
+        }
+
+        private void Hyperlink_RequestNavigate(object sender, System.Windows.Navigation.RequestNavigateEventArgs e)
+        {
+            System.Diagnostics.Process.Start(e.Uri.ToString());
         }
     }
 }

--- a/ControlWindowWPF/ControlWindowWPF/MainWindow.xaml.cs
+++ b/ControlWindowWPF/ControlWindowWPF/MainWindow.xaml.cs
@@ -127,6 +127,8 @@ namespace VirtualMotionCaptureControlPanel
             if (isSliderSetting == false && Globals.Client != null) await Globals.Client.SendCommandAsync(command);
         }
 
+        private PipeCommands.LogNotify lastLog = null;
+
         private void Client_Received(object sender, DataReceivedEventArgs e)
         {
             Dispatcher.Invoke(async () =>
@@ -307,6 +309,12 @@ namespace VirtualMotionCaptureControlPanel
                 {
                     var d = (PipeCommands.KeyUp)e.Data;
                     logKeyConfig(d.Config, false);
+                }
+                else if (e.CommandType == typeof(PipeCommands.LogNotify))
+                {
+                    var d = (PipeCommands.LogNotify)e.Data;
+                    UnityLogStatusTextBlock.Text = "["+d.type.ToString()+"] "+d.condition;
+                    lastLog = d;
                 }
             });
         }
@@ -689,6 +697,16 @@ namespace VirtualMotionCaptureControlPanel
         {
             LightColorButton.Background = new SolidColorBrush(e);
             await Globals.Client?.SendCommandAsync(new PipeCommands.ChangeLightColor { a = e.A / 255f, r = e.R / 255f, g = e.G / 255f, b = e.B / 255f });
+        }
+
+        private void StatusBar_MouseDoubleClick(object sender, MouseButtonEventArgs e)
+        {
+            if (lastLog != null)
+            {
+                string trace = "[" + lastLog.type.ToString() + "] " + lastLog.condition + "\n" + lastLog.stackTrace;
+                Clipboard.SetText(trace);
+                MessageBox.Show("Trace log has copied.", "Trace log", MessageBoxButton.OK, MessageBoxImage.Information);
+            }
         }
     }
 }

--- a/UnityMemoryMappedFile/PipeCommands.cs
+++ b/UnityMemoryMappedFile/PipeCommands.cs
@@ -439,8 +439,24 @@ namespace UnityMemoryMappedFile
         {
             public int antiAliasing { get; set; }
         }
+
+        public class LogNotify {
+            public string condition { get; set; }
+            public string stackTrace { get; set; }
+            public NotifyLogTypes type { get; set; }
+            public int errorCount { get; set; }
+        }
+
     }
 
+    public enum NotifyLogTypes
+    {
+        Error=0,
+        Assert=1,
+        Warning=2,
+        Log=3,
+        Exception=4,
+    }
 
     public enum CameraTypes
     {


### PR DESCRIPTION
先のPull Requestの続きです

・Unity LogのWPF画面出力機能
　WPF画面の下にステータスバーを追加。Unity側で発生したエラーや警告を表示できるようにしました。
　ステータスバーをダブルクリックすると詳細なトレースログも取れます。

・デザイン調整
　チェックボックスやボタンなどの位置ずれの一部を直しました

・ヘルプタブの追加
　0.42backportを参考に、公式サイトへのリンクを記載したタブを追加しました。

・異常エラー時の強制終了機能
　Unity側で致命的なエラーが1万回異常発生した場合、強制終了するコードを追加しました。
　(フェイルセーフですが、1万回だと毎フレーム出てたとしても3分掛かります)


![image](https://user-images.githubusercontent.com/33391403/82125584-e72ad080-97e1-11ea-8a58-6a66b1bb6f4b.png)
