### PR TITLE
新しい設定項目の翻訳対応

### DIFF
--- a/ControlWindowWPF/ControlWindowWPF/Resources/Chinese.xaml
+++ b/ControlWindowWPF/ControlWindowWPF/Resources/Chinese.xaml
@@ -225,12 +225,25 @@
     <system:String x:Key="SettingWindow_SelectedItemError">请选择一个控制器当做相机</system:String>
     <system:String x:Key="SettingWindow_ExportExternalCameraConfig">输出externalcamera.cfg</system:String>
     <system:String x:Key="SettingWindow_ExportExternalCameraConfig_ToolTip">输出externalcamera.cfg以校准VR游戏的相机</system:String>
-    <system:String x:Key="SettingWindow_ExternalMotionSender">发送外部动作</system:String>
+    <system:String x:Key="SettingWindow_ExternalMotionSender">发送外部动作(VMCProtocol)</system:String>
     <system:String x:Key="SettingWindow_ExternalMotionSenderEnable">成功用OSC运动发送</system:String>
     <system:String x:Key="SettingWindow_ExternalMotionSenderTransmissionInterval">传输间隔（每隔指定的帧一次）</system:String>
-    <system:String x:Key="SettingWindow_ExternalMotionReceiver">接受外部动作</system:String>
+    <system:String x:Key="SettingWindow_ExternalMotionReceiver">接受外部动作(VMCProtocol)</system:String>
     <system:String x:Key="SettingWindow_ExternalMotionReceiverEnable">在OSC上启用运动接收</system:String>
-
+   	<system:String x:Key="SettingWindow_MIDI_CC_BlendShape">MIDI CC BlendShape</system:String>
+   	<system:String x:Key="SettingWindow_MidiCCBlendShapeSetting">Knob to BlendShape setting</system:String>
+   	<system:String x:Key="SettingWindow_PreventLosingTracking">Prevent losing tracking</system:String>
+   	<system:String x:Key="SettingWindow_TrackingFilterEnable">Enable</system:String>
+   	<system:String x:Key="SettingWindow_TrackingFilterHmdEnable">HMD</system:String>
+   	<system:String x:Key="SettingWindow_TrackingFilterControllerEnable">Controller</system:String>
+   	<system:String x:Key="SettingWindow_TrackingFilterTrackerEnable">Tracker</system:String>
+   	<system:String x:Key="SettingWindow_ModelModifier">Model modifier</system:String>
+   	<system:String x:Key="SettingWindow_FixKneeRotation">Fix Knee rotation</system:String>
+   	<system:String x:Key="SettingWindow_TrackingOption">Tracking Option</system:String>
+   	<system:String x:Key="SettingWindow_HandleControllerAsTracker">Handle Controller as Tracker</system:String>
+   	<system:String x:Key="SettingWindow_QualitySettings">Quality Settings</system:String>
+   	<system:String x:Key="SettingWindow_AntiAliasing">AntiAliasing</system:String>
+   	
     
 
     <!-- TrackerConfigWindow -->

--- a/ControlWindowWPF/ControlWindowWPF/Resources/English.xaml
+++ b/ControlWindowWPF/ControlWindowWPF/Resources/English.xaml
@@ -225,12 +225,25 @@
     <system:String x:Key="SettingWindow_SelectedItemError">Please select tracker to assign camera</system:String>
     <system:String x:Key="SettingWindow_ExportExternalCameraConfig">Export externalcamera.cfg</system:String>
     <system:String x:Key="SettingWindow_ExportExternalCameraConfig_ToolTip">Export externalcamera.cfg to synthesize model into VR game</system:String>
-    <system:String x:Key="SettingWindow_ExternalMotionSender">External motion sender</system:String>
+    <system:String x:Key="SettingWindow_ExternalMotionSender">VMCProtocol Motion sender</system:String>
     <system:String x:Key="SettingWindow_ExternalMotionSenderEnable">Enable OSC motion sender</system:String>
     <system:String x:Key="SettingWindow_ExternalMotionSenderTransmissionInterval">Interval(once every specified frame)</system:String>
-    <system:String x:Key="SettingWindow_ExternalMotionReceiver">External motion receiver</system:String>
+    <system:String x:Key="SettingWindow_ExternalMotionReceiver">VMCProtocol Motion receiver</system:String>
     <system:String x:Key="SettingWindow_ExternalMotionReceiverEnable">Enable OSC motion receiver</system:String>
-    
+   	<system:String x:Key="SettingWindow_MIDI_CC_BlendShape">MIDI CC BlendShape</system:String>
+   	<system:String x:Key="SettingWindow_MidiCCBlendShapeSetting">Knob to BlendShape setting</system:String>
+   	<system:String x:Key="SettingWindow_PreventLosingTracking">Prevent losing tracking</system:String>
+   	<system:String x:Key="SettingWindow_TrackingFilterEnable">Enable</system:String>
+   	<system:String x:Key="SettingWindow_TrackingFilterHmdEnable">HMD</system:String>
+   	<system:String x:Key="SettingWindow_TrackingFilterControllerEnable">Controller</system:String>
+   	<system:String x:Key="SettingWindow_TrackingFilterTrackerEnable">Tracker</system:String>
+   	<system:String x:Key="SettingWindow_ModelModifier">Model modifier</system:String>
+   	<system:String x:Key="SettingWindow_FixKneeRotation">Fix Knee rotation</system:String>
+   	<system:String x:Key="SettingWindow_TrackingOption">Tracking Option</system:String>
+   	<system:String x:Key="SettingWindow_HandleControllerAsTracker">Handle Controller as Tracker</system:String>
+   	<system:String x:Key="SettingWindow_QualitySettings">Quality Settings</system:String>
+   	<system:String x:Key="SettingWindow_AntiAliasing">AntiAliasing</system:String>
+   	
 
     <!-- TrackerConfigWindow -->
     <system:String x:Key="TrackerConfigWindowTitle">Tracker assignment setting</system:String>

--- a/ControlWindowWPF/ControlWindowWPF/Resources/Japanese.xaml
+++ b/ControlWindowWPF/ControlWindowWPF/Resources/Japanese.xaml
@@ -226,14 +226,27 @@
     <system:String x:Key="SettingWindow_SelectedItemError">カメラを割り当てるトラッカーを選択してください</system:String>
     <system:String x:Key="SettingWindow_ExportExternalCameraConfig">externalcamera.cfgの書き出し</system:String>
     <system:String x:Key="SettingWindow_ExportExternalCameraConfig_ToolTip">VRゲームにモデルを合成するためのexternalcamera.cfgを出力します</system:String>
-    <system:String x:Key="SettingWindow_ExternalMotionSender">外部にモーション送信</system:String>
+	<system:String x:Key="SettingWindow_ExternalMotionSender">モーション送信(VMCProtocol)</system:String>
     <system:String x:Key="SettingWindow_ExternalMotionSenderEnable">OSCでモーション送信を有効にする</system:String>
     <system:String x:Key="SettingWindow_ExternalMotionSenderTransmissionInterval">送信間隔(指定フレームに1回)</system:String>
-    <system:String x:Key="SettingWindow_ExternalMotionReceiver">外部からモーション受信</system:String>
-    <system:String x:Key="SettingWindow_ExternalMotionReceiverEnable">OSCでモーション受信を有効にする</system:String>
+	<system:String x:Key="SettingWindow_ExternalMotionReceiver">モーション受信(VMCProtocol)</system:String>
+	<system:String x:Key="SettingWindow_ExternalMotionReceiverEnable">OSCでモーション受信を有効にする</system:String>
+	<system:String x:Key="SettingWindow_MIDI_CC_BlendShape">MIDI CC BlendShape割り当て</system:String>
+	<system:String x:Key="SettingWindow_MidiCCBlendShapeSetting">MIDI CCつまみ割り当て設定を開く</system:String>
+	<system:String x:Key="SettingWindow_PreventLosingTracking">トラッキングロスト時の飛び軽減</system:String>
+	<system:String x:Key="SettingWindow_TrackingFilterEnable">有効</system:String>
+	<system:String x:Key="SettingWindow_TrackingFilterHmdEnable">HMD</system:String>
+	<system:String x:Key="SettingWindow_TrackingFilterControllerEnable">コントローラ</system:String>
+	<system:String x:Key="SettingWindow_TrackingFilterTrackerEnable">トラッカー</system:String>
+	<system:String x:Key="SettingWindow_ModelModifier">モデル調整</system:String>
+	<system:String x:Key="SettingWindow_FixKneeRotation">膝の回転の修正を試みる</system:String>
+	<system:String x:Key="SettingWindow_TrackingOption">トラッキングオプション</system:String>
+	<system:String x:Key="SettingWindow_HandleControllerAsTracker">コントローラをトラッカーとして扱う(特殊持ち対応)</system:String>
+	<system:String x:Key="SettingWindow_QualitySettings">描画品質</system:String>
+	<system:String x:Key="SettingWindow_AntiAliasing">アンチエイリアス</system:String>
 
 
-    <!-- TrackerConfigWindow -->
+	<!-- TrackerConfigWindow -->
     <system:String x:Key="TrackerConfigWindowTitle">トラッカー割り当て設定</system:String>
 
     <system:String x:Key="TrackerConfigWindow_TrackerConfig">トラッカー割り当て</system:String>

--- a/ControlWindowWPF/ControlWindowWPF/Resources/Korean.xaml
+++ b/ControlWindowWPF/ControlWindowWPF/Resources/Korean.xaml
@@ -226,15 +226,28 @@
     <system:String x:Key="SettingWindow_SelectedItemError">카메라를 할당할 트래커를 선택해주세요</system:String>
     <system:String x:Key="SettingWindow_ExportExternalCameraConfig">externalcamera.cfg 출력</system:String>
     <system:String x:Key="SettingWindow_ExportExternalCameraConfig_ToolTip">VR게임에 모델을 합성하기 위한 externalcamera.cfg를 출력합니다</system:String>
-    <system:String x:Key="SettingWindow_ExternalMotionSender">외부로 모션을 송신</system:String>
+	<system:String x:Key="SettingWindow_ExternalMotionSender">외부로 모션을 송신(VMCProtocol)</system:String>
     <system:String x:Key="SettingWindow_ExternalMotionSenderEnable">OSC로 모션송신을 활성화합니다</system:String>
     <system:String x:Key="SettingWindow_ExternalMotionSenderTransmissionInterval">전송 간격 (지정 프레임에 1 회)</system:String>
-    <system:String x:Key="SettingWindow_ExternalMotionReceiver">외부에서 모션 수신</system:String>
+	<system:String x:Key="SettingWindow_ExternalMotionReceiver">외부에서 모션 수신(VMCProtocol)</system:String>
     <system:String x:Key="SettingWindow_ExternalMotionReceiverEnable">OSC에서 모션의 수신을 활성화합니다</system:String>
+	<system:String x:Key="SettingWindow_MIDI_CC_BlendShape">MIDI CC BlendShape</system:String>
+	<system:String x:Key="SettingWindow_MidiCCBlendShapeSetting">Knob to BlendShape setting</system:String>
+	<system:String x:Key="SettingWindow_PreventLosingTracking">Prevent losing tracking</system:String>
+	<system:String x:Key="SettingWindow_TrackingFilterEnable">Enable</system:String>
+	<system:String x:Key="SettingWindow_TrackingFilterHmdEnable">HMD</system:String>
+	<system:String x:Key="SettingWindow_TrackingFilterControllerEnable">Controller</system:String>
+	<system:String x:Key="SettingWindow_TrackingFilterTrackerEnable">Tracker</system:String>
+	<system:String x:Key="SettingWindow_ModelModifier">Model modifier</system:String>
+	<system:String x:Key="SettingWindow_FixKneeRotation">Fix Knee rotation</system:String>
+	<system:String x:Key="SettingWindow_TrackingOption">Tracking Option</system:String>
+	<system:String x:Key="SettingWindow_HandleControllerAsTracker">Handle Controller as Tracker</system:String>
+	<system:String x:Key="SettingWindow_QualitySettings">Quality Settings</system:String>
+	<system:String x:Key="SettingWindow_AntiAliasing">AntiAliasing</system:String>
 
 
 
-    <!-- TrackerConfigWindow -->
+	<!-- TrackerConfigWindow -->
     <system:String x:Key="TrackerConfigWindowTitle">트래커 할당 설정</system:String>
 
     <system:String x:Key="TrackerConfigWindow_TrackerConfig">트래커 할당</system:String>

--- a/ControlWindowWPF/ControlWindowWPF/SettingWindow.xaml
+++ b/ControlWindowWPF/ControlWindowWPF/SettingWindow.xaml
@@ -189,35 +189,35 @@
                         </Grid>
                     </DockPanel>
                 </GroupBox>
-                <GroupBox Header="MIDI CC BlendShape">
-                    <Button Content="Knob to BlendShape setting" Name="MidiCCBlendShapeSettingButton" Click="MidiCCBlendShapeSettingButton_Click"/>
+				<GroupBox Header="{DynamicResource SettingWindow_MIDI_CC_BlendShape}">
+					<Button Content="{DynamicResource SettingWindow_MidiCCBlendShapeSetting}" Name="MidiCCBlendShapeSettingButton" Click="MidiCCBlendShapeSettingButton_Click"/>
                 </GroupBox>
-                <GroupBox Header="Prevent losing tracking">
+				<GroupBox Header="{DynamicResource SettingWindow_PreventLosingTracking}">
                     <GroupBox>
                         <GroupBox.Header>
-                            <CheckBox Content="Enable" Name="TrackingFilterEnable" Checked="TrackingFilterEnable_Changed" Unchecked="TrackingFilterEnable_Changed"/>
+							<CheckBox Content="{DynamicResource SettingWindow_TrackingFilterEnable}" Name="TrackingFilterEnable" Checked="TrackingFilterEnable_Changed" Unchecked="TrackingFilterEnable_Changed"/>
                         </GroupBox.Header>
                         <WrapPanel>
-                            <CheckBox Content="HMD" Name="TrackingFilterHmdEnable" Checked="TrackingFilterEnable_Changed" Unchecked="TrackingFilterEnable_Changed"/>
-                            <CheckBox Content="Controller" Name="TrackingFilterControllerEnable" Checked="TrackingFilterEnable_Changed" Unchecked="TrackingFilterEnable_Changed"/>
-                            <CheckBox Content="Tracker" Name="TrackingFilterTrackerEnable" Checked="TrackingFilterEnable_Changed" Unchecked="TrackingFilterEnable_Changed"/>
+							<CheckBox Content="{DynamicResource SettingWindow_TrackingFilterHmdEnable}" Name="TrackingFilterHmdEnable" Checked="TrackingFilterEnable_Changed" Unchecked="TrackingFilterEnable_Changed"/>
+							<CheckBox Content="{DynamicResource SettingWindow_TrackingFilterControllerEnable}" Name="TrackingFilterControllerEnable" Checked="TrackingFilterEnable_Changed" Unchecked="TrackingFilterEnable_Changed"/>
+							<CheckBox Content="{DynamicResource SettingWindow_TrackingFilterTrackerEnable}" Name="TrackingFilterTrackerEnable" Checked="TrackingFilterEnable_Changed" Unchecked="TrackingFilterEnable_Changed"/>
                         </WrapPanel>
                     </GroupBox>
                 </GroupBox>
-                <GroupBox Header="Model modifier">
+				<GroupBox Header="{DynamicResource SettingWindow_ModelModifier}">
                     <StackPanel Orientation="Vertical">
-                        <CheckBox Content="Fix Knee rotation" Name="FixKneeRotationCheckBox" Checked="FixKneeRotationCheckBox_Changed" Unchecked="FixKneeRotationCheckBox_Changed"/>
+						<CheckBox Content="{DynamicResource SettingWindow_FixKneeRotation}" Name="FixKneeRotationCheckBox" Checked="FixKneeRotationCheckBox_Changed" Unchecked="FixKneeRotationCheckBox_Changed"/>
                     </StackPanel>
                 </GroupBox>
-                <GroupBox Header="Tracking Option">
+				<GroupBox Header="{DynamicResource SettingWindow_TrackingOption}">
                     <StackPanel Orientation="Vertical">
-                        <CheckBox Content="Handle Controller as Tracker" Name="HandleControllerAsTrackerCheckBox" Checked="HandleControllerAsTrackerCheckBox_Changed" Unchecked="HandleControllerAsTrackerCheckBox_Changed" />
+						<CheckBox Content="{DynamicResource SettingWindow_HandleControllerAsTracker}" Name="HandleControllerAsTrackerCheckBox" Checked="HandleControllerAsTrackerCheckBox_Changed" Unchecked="HandleControllerAsTrackerCheckBox_Changed" />
                     </StackPanel>
                 </GroupBox>
-                <GroupBox Header="Quality Settings">
+				<GroupBox Header="{DynamicResource SettingWindow_QualitySettings}">
                     <StackPanel Orientation="Vertical">
                         <DockPanel>
-                            <TextBlock Text="AntiAliasing" DockPanel.Dock="Left"/>
+							<TextBlock Text="{DynamicResource SettingWindow_AntiAliasing}" DockPanel.Dock="Left"/>
                             <TextBlock Text="x" DockPanel.Dock="Left" Margin="10,0,0,0"/>
                             <ComboBox Name="AntiAliasingComboBox" SelectionChanged="AntiAliasingComboBox_SelectionChanged"/>
                         </DockPanel>


### PR DESCRIPTION
最近追加された設定項目が、ダイナミックリソース対応されていなかったので、
ダイナミックリソース対応をし、日本語だけ対応しておきました。
他の言語は、元の表記のまま(英語)です。

また、モーション送信・受信のところにVMCProtocolの表記を追加しました。
![image](https://user-images.githubusercontent.com/33391403/82147992-75f42780-988c-11ea-81b1-5f833a41e447.png)
