### PR TITLE
MIDI Note As CC

### DIFF
--- a/Assets/ExternalSender/MidiCCWrapper.cs
+++ b/Assets/ExternalSender/MidiCCWrapper.cs
@@ -9,6 +9,9 @@ public class MidiCCWrapper : MonoBehaviour {
     public const int KNOBS = 128; //最大ノブ数
     public const float Threshold = 0.5f; //bool判定しきい値
 
+    //MIDI NoteをMIDI CCとして扱う
+    public bool MIDINoteAsCC = false;
+
     //MIDIJack集約用デリゲートプロキシ(入力を即時通知する)
     public Action<MidiJack.MidiChannel, int, float> noteOnDelegateProxy = null;
     public Action<MidiJack.MidiChannel, int> noteOffDelegateProxy = null;
@@ -42,10 +45,17 @@ public class MidiCCWrapper : MonoBehaviour {
                     noteOffDelegateProxy.Invoke(channel, note);
                 }
             }
+            if (MIDINoteAsCC) {
+                KnobUpdated(channel, note, velocity);
+            }
         };
         MidiJack.MidiMaster.noteOffDelegate += (MidiJack.MidiChannel channel, int note) => {
             if (noteOffDelegateProxy != null) {
                 noteOffDelegateProxy.Invoke(channel, note);
+            }
+            if (MIDINoteAsCC)
+            {
+                KnobUpdated(channel, note, 0);
             }
         };
 

--- a/Assets/Scripts/ControlWPFWindow.cs
+++ b/Assets/Scripts/ControlWPFWindow.cs
@@ -207,8 +207,9 @@ public class ControlWPFWindow : MonoBehaviour
             if (!doKeyConfig) CheckKey(config, value);
         };
 
-        MidiJack.MidiMaster.knobDelegate += (MidiJack.MidiChannel channel, int knobNo, float value) =>
+        midiCCWrapper.knobUpdateFloatDelegate += (int knobNo, float value) =>
         {
+            MidiJack.MidiChannel channel = MidiJack.MidiChannel.Ch1; //仮でCh1
             CheckKnobUpdated(channel, knobNo, value);
         };
     }


### PR DESCRIPTION
MIDI NoteとVelocityを、MIDI CCとして解釈する機能を追加するパッチです。
MidiCCWrapper.csにbool値 MIDINoteAsCC が1つ増えています。
既定はfalse(無効)です。
この値をGUIなどで操作できるようにするかはおまかせします。