### PR TITLE
VMT追加実装対応

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,4 @@ sysinfo.txt
 *.apk
 *.unitypackage
 common.json
+Assets/_TerrainAutoUpgrade/

--- a/Assets/ExternalPlugins/VirtualMotionTracker/VMTClient.cs
+++ b/Assets/ExternalPlugins/VirtualMotionTracker/VMTClient.cs
@@ -16,6 +16,7 @@ public class VMTClient : MonoBehaviour
     void Start()
     {
         client = GetComponent<uOscClient>();
+        SendRoomMatrixTemporary(); //とりあえず起動時にぶん投げておく
     }
 
     public int GetNo()
@@ -46,7 +47,20 @@ public class VMTClient : MonoBehaviour
         sendEnable = en;
     }
 
-    private float lastRoomMatrixSendTime = 0;
+    public void SendRoomMatrixTemporary()
+    {
+        if (client == null || sendEnable == false)
+        {
+            return;
+        }
+
+        HmdMatrix34_t m = new HmdMatrix34_t();
+        OpenVR.ChaperoneSetup.GetWorkingStandingZeroPoseToRawTrackingPose(ref m);
+        client.Send("/VMT/SetRoomMatrix/Temporary",
+            m.m0, m.m1, m.m2, m.m3,
+            m.m4, m.m5, m.m6, m.m7,
+            m.m8, m.m9, m.m10, m.m11);
+    }
 
     void Update()
     {
@@ -69,18 +83,6 @@ public class VMTClient : MonoBehaviour
                 (float)target.localRotation.z,
                 (float)target.localRotation.w
             );
-
-            if (lastRoomMatrixSendTime + 5f < Time.realtimeSinceStartup)
-            {
-                lastRoomMatrixSendTime = Time.realtimeSinceStartup;
-
-                HmdMatrix34_t m = new HmdMatrix34_t();
-                OpenVR.ChaperoneSetup.GetWorkingStandingZeroPoseToRawTrackingPose(ref m);
-                client.Send("/VMT/SetRoomMatrix/Temporary",
-                    m.m0, m.m1, m.m2, m.m3,
-                    m.m4, m.m5, m.m6, m.m7,
-                    m.m8, m.m9, m.m10, m.m11);
-            }
         }
     }
 

--- a/Assets/ExternalPlugins/VirtualMotionTracker/VMTServer.cs
+++ b/Assets/ExternalPlugins/VirtualMotionTracker/VMTServer.cs
@@ -13,10 +13,11 @@ public class VMTServer : MonoBehaviour
 
     private static string driverVersion = null;
     private static string installPath = null;
+    private static uOSC.uOscServer server;
 
     private void Start()
     {
-        var server = GetComponent<uOSC.uOscServer>();
+        server = GetComponent<uOSC.uOscServer>();
         server.onDataReceived.AddListener(OnDataReceived);
     }
 
@@ -42,6 +43,17 @@ public class VMTServer : MonoBehaviour
 
     public static async Task<string> InstallVMT()
     {
+        server.enabled = true; //インストール情報を調べるために一時的に有効化
+
+        await Task.Delay(1000);
+        //インストールパスが受信できていない場合少し待つ
+        if (string.IsNullOrEmpty(installPath))
+        {
+            await Task.Delay(2000);
+        }
+
+        server.enabled = false; //無効化
+
         if (string.IsNullOrEmpty(driverVersion) == false)
         {
             return "Please uninstall VMT before install.\nインストールを続ける前に、VMTをアンインストールしてください";
@@ -68,7 +80,11 @@ public class VMTServer : MonoBehaviour
         {
             return "Error:" + ex.Message + "\n" + ex.StackTrace;
         }
+#if UNITY_EDITOR
+        return "Restart skipped due to application running on editor.";
+#else
         return null;
+#endif
     }
 
     public static async Task<string> UninstallVMT()
@@ -76,11 +92,17 @@ public class VMTServer : MonoBehaviour
         string driverPath_rel = @"C:\VirtualMotionTracker\vmt";
         string driverPath = System.IO.Path.GetFullPath(driverPath_rel);
 
+        server.enabled = true; //インストール情報を調べるために一時的に有効化
+
+        await Task.Delay(1000);
+        //インストールパスが受信できていない場合少し待つ
         if (string.IsNullOrEmpty(installPath))
         {
-            //インストールパスが受信できていない場合少し待つ
             await Task.Delay(2000);
         }
+
+        server.enabled = false; //無効化
+
 
         if (string.IsNullOrEmpty(installPath) == false)
         {
@@ -106,7 +128,11 @@ public class VMTServer : MonoBehaviour
         {
             return "Error:" + ex.Message + "\n" + ex.StackTrace;
         }
+#if UNITY_EDITOR
+        return "Restart skipped due to application running on editor.";
+#else
         return null;
+#endif
     }
 
 }

--- a/Assets/Scripts/ControlWPFWindow.cs
+++ b/Assets/Scripts/ControlWPFWindow.cs
@@ -988,6 +988,7 @@ public class ControlWPFWindow : MonoBehaviour
     {
         vmtClient.SetNo(no);
         vmtClient.SetEnable(enable);
+        vmtClient.SendRoomMatrixTemporary();
 
         CurrentSettings.VirtualMotionTrackerNo = no;
         CurrentSettings.VirtualMotionTrackerEnable = enable;

--- a/ControlWindowWPF/ControlWindowWPF/Resources/Chinese.xaml
+++ b/ControlWindowWPF/ControlWindowWPF/Resources/Chinese.xaml
@@ -252,7 +252,7 @@
    	<system:String x:Key="SettingWindow_VirtualMotionTracker">Virtual Motion Tracker (VMT)</system:String>
 	<system:String x:Key="SettingWindow_VirtualMotionTrackerEnable">Enable</system:String>
 	<system:String x:Key="SettingWindow_VirtualMotionTrackerInstallSuccess">Success! Restart SteamVR and VirtualMotionCapture. Press OK and wait auto restart.</system:String>
-
+	<system:String x:Key="SettingWindow_VMTContinue">Continue VMT setup? Game will be interrupted, and VR system will restart.</system:String>
     
 
     <!-- TrackerConfigWindow -->

--- a/ControlWindowWPF/ControlWindowWPF/Resources/English.xaml
+++ b/ControlWindowWPF/ControlWindowWPF/Resources/English.xaml
@@ -252,6 +252,7 @@
    	<system:String x:Key="SettingWindow_VirtualMotionTracker">Virtual Motion Tracker (VMT)</system:String>
 	<system:String x:Key="SettingWindow_VirtualMotionTrackerEnable">Enable</system:String>
 	<system:String x:Key="SettingWindow_VirtualMotionTrackerInstallSuccess">Success! Restart SteamVR and VirtualMotionCapture. Press OK and wait auto restart.</system:String>
+	<system:String x:Key="SettingWindow_VMTContinue">Continue VMT setup? Game will be interrupted, and VR system will restart.</system:String>
 
 
     <!-- TrackerConfigWindow -->

--- a/ControlWindowWPF/ControlWindowWPF/Resources/Japanese.xaml
+++ b/ControlWindowWPF/ControlWindowWPF/Resources/Japanese.xaml
@@ -253,9 +253,9 @@
 	<system:String x:Key="SettingWindow_VirtualMotionTracker">Virtual Motion Tracker (VMT)</system:String>
     <system:String x:Key="SettingWindow_VirtualMotionTrackerEnable">有効</system:String>
     <system:String x:Key="SettingWindow_VirtualMotionTrackerInstallSuccess">成功しました。SteamVRとバーチャルモーションキャプチャーが自動で再起動されますので、OKを押してしばらくお待ちください。</system:String>
+	<system:String x:Key="SettingWindow_VMTContinue">VMTのセットアップを実行しますか？ゲームが中断され、VRシステムは自動で再起動します。</system:String>
 
-
-    <!-- TrackerConfigWindow -->
+	<!-- TrackerConfigWindow -->
     <system:String x:Key="TrackerConfigWindowTitle">トラッカー割り当て設定</system:String>
 
     <system:String x:Key="TrackerConfigWindow_TrackerConfig">トラッカー割り当て</system:String>

--- a/ControlWindowWPF/ControlWindowWPF/Resources/Korean.xaml
+++ b/ControlWindowWPF/ControlWindowWPF/Resources/Korean.xaml
@@ -253,7 +253,7 @@
 	<system:String x:Key="SettingWindow_VirtualMotionTracker">Virtual Motion Tracker (VMT)</system:String>
     <system:String x:Key="SettingWindow_VirtualMotionTrackerEnable">Enable</system:String>
     <system:String x:Key="SettingWindow_VirtualMotionTrackerInstallSuccess">Success! Restart SteamVR and VirtualMotionCapture. Press OK and wait auto restart.</system:String>
-
+	<system:String x:Key="SettingWindow_VMTContinue">Continue VMT setup? Game will be interrupted, and VR system will restart.</system:String>
 
     <!-- TrackerConfigWindow -->
     <system:String x:Key="TrackerConfigWindowTitle">트래커 할당 설정</system:String>

--- a/ControlWindowWPF/ControlWindowWPF/SettingWindow.xaml.cs
+++ b/ControlWindowWPF/ControlWindowWPF/SettingWindow.xaml.cs
@@ -431,6 +431,8 @@ namespace VirtualMotionCaptureControlPanel
             if (process32.ExitCode == 0 && process64.ExitCode == 0)
             {
                 MessageBox.Show(LanguageSelector.Get("SettingWindow_SuccessDriverInstall"));
+                WebCamEnableCheckBox.IsChecked = true; //インストールと同時にチェックを入れる
+                UpdateWebCamConfig();
             }
             else
             {
@@ -468,6 +470,8 @@ namespace VirtualMotionCaptureControlPanel
                     return;
                 }
                 MessageBox.Show(LanguageSelector.Get("SettingWindow_SuccessDriverUninstall"));
+                WebCamEnableCheckBox.IsChecked = false; //アンストールと同時にチェックを外す
+                UpdateWebCamConfig();
             }
             else
             {
@@ -806,16 +810,23 @@ namespace VirtualMotionCaptureControlPanel
 
         private async void VMTInstallButton_Click(object sender, RoutedEventArgs e)
         {
+            VirtualMotionTrackerEnableCheckBox.IsChecked = true; //インストールと同時にチェックを入れる
             await SetupVirtualMotionTracker(true);
         }
 
         private async void VMTUninstallButton_Click(object sender, RoutedEventArgs e)
         {
+            VirtualMotionTrackerEnableCheckBox.IsChecked = false; //アンイストールと同時にチェックを外す
             await SetupVirtualMotionTracker(false);
         }
 
         private async Task SetupVirtualMotionTracker(bool install)
         {
+            var messageBoxResult = MessageBox.Show(LanguageSelector.Get("SettingWindow_VMTContinue"), LanguageSelector.Get("Confirm"), MessageBoxButton.OKCancel, MessageBoxImage.Question);
+            if (messageBoxResult != MessageBoxResult.OK) {
+                return;
+            }
+
             if (install)
             {
                 try
@@ -840,12 +851,12 @@ namespace VirtualMotionCaptureControlPanel
                 {
                     if (string.IsNullOrEmpty(data.result))
                     {
-                        MessageBox.Show(LanguageSelector.Get("SettingWindow_VirtualMotionTrackerInstallSuccess"));
+                        MessageBox.Show(LanguageSelector.Get("SettingWindow_VirtualMotionTrackerInstallSuccess"), "VMT Setup", MessageBoxButton.OK, MessageBoxImage.Information);
                         RestartSteamVRandVirtualMotionCapture();
                     }
                     else
                     {
-                        MessageBox.Show(data.result);
+                        MessageBox.Show(data.result, LanguageSelector.Get("Error"), MessageBoxButton.OK, MessageBoxImage.Error);
                     }
                 });
             });


### PR DESCRIPTION
リクエスト先のブランチを間違えたため、再発行しています。

以下の追加・変更をしました。
・VMTインストール/アンインストール時に、有効チェックを入れる/外す
・仮想WebCamインストール/アンインストール時に、有効チェックを入れる/外す
・VMT用のuOSCサーバーを必要なときだけ有効にする(注記参照)
・UnityEditorで実行中はSteamVRの再起動をスキップする
・VMTのインストール/アンインストール時に実行可否を問うダイアログを追加(日/英対応済み、韓・中は英で追加)
・Temporary room matrixはVMTオン時と設定読み込み時に送信するように変更
・gitignoreにAssets/_TerrainAutoUpgrade/を追加
・一部のダイアログを修正

注記:
　・Unityシーン上で、VMT用のuOSC ServerのEnableを外してください
　・キャリブレーション時にもRoomMatrixを送ったほうが良いと考える場合は、キャリブレーションあたりに以下の1行追加してください
　 vmtClient.SendRoomMatrixTemporary();

ある程度の動作確認はしていますが、ViveSRなど未導入なのもあり、確認をお願いします。