### PR TITLE
PostProcessing機能の追加

### DIFF
--- a/Assets/PostProcessingManager.cs
+++ b/Assets/PostProcessingManager.cs
@@ -122,6 +122,13 @@ public class PostProcessingManager : MonoBehaviour
 
         postProcessVolume.sharedProfile = sp;
 
-
+        if (d.TurnOffAmbientLight)
+        {
+            RenderSettings.ambientLight = Color.black;
+            RenderSettings.ambientMode = UnityEngine.Rendering.AmbientMode.Flat;
+        }
+        else {
+            RenderSettings.ambientMode = UnityEngine.Rendering.AmbientMode.Skybox;
+        }
     }
 }

--- a/Assets/PostProcessingManager.cs
+++ b/Assets/PostProcessingManager.cs
@@ -13,7 +13,7 @@ public class PostProcessingManager : MonoBehaviour
         postProcessVolume = gameObject.AddComponent<PostProcessVolume>();
     }
 
-    public void Apply(PipeCommands.SetPostProcessing d)
+    public void Apply(ControlWPFWindow.Settings d)
     {
         postProcessVolume.isGlobal = true;
         var sp = postProcessVolume.sharedProfile;
@@ -27,11 +27,11 @@ public class PostProcessingManager : MonoBehaviour
         }
         bloom.active = true;
         bloom.enabled.overrideState = true;
-        bloom.enabled.value = d.Bloom_Enable;
+        bloom.enabled.value = d.PPS_Bloom_Enable;
         bloom.intensity.overrideState = true;
-        bloom.intensity.value = d.Bloom_Intensity;
+        bloom.intensity.value = d.PPS_Bloom_Intensity;
         bloom.threshold.overrideState = true;
-        bloom.threshold.value = d.Bloom_Threshold;
+        bloom.threshold.value = d.PPS_Bloom_Threshold;
 
         var dof = sp.GetSetting<DepthOfField>();
         if (dof == null) {
@@ -39,16 +39,16 @@ public class PostProcessingManager : MonoBehaviour
         }
         dof.active = true;
         dof.enabled.overrideState = true;
-        dof.enabled.value = d.DoF_Enable;
+        dof.enabled.value = d.PPS_DoF_Enable;
         dof.focusDistance.overrideState = true;
-        dof.focusDistance.value = d.DoF_FocusDistance;
+        dof.focusDistance.value = d.PPS_DoF_FocusDistance;
         dof.aperture.overrideState = true;
-        dof.aperture.value = d.DoF_Aperture;
+        dof.aperture.value = d.PPS_DoF_Aperture;
         dof.focalLength.overrideState = true;
-        dof.focalLength.value = d.DoF_FocusLength;
+        dof.focalLength.value = d.PPS_DoF_FocusLength;
 
         dof.kernelSize.overrideState = true;
-        switch (d.DoF_MaxBlurSize) {
+        switch (d.PPS_DoF_MaxBlurSize) {
             case 0:
                 dof.kernelSize.value = KernelSize.Small;
                 break;
@@ -73,11 +73,11 @@ public class PostProcessingManager : MonoBehaviour
         }
         cg.active = true;
         cg.enabled.overrideState = true;
-        cg.enabled.value = d.CG_Enable;
+        cg.enabled.value = d.PPS_CG_Enable;
         cg.saturation.overrideState = true;
-        cg.saturation.value = d.CG_Saturation;
+        cg.saturation.value = d.PPS_CG_Saturation;
         cg.contrast.overrideState = true;
-        cg.contrast.value = d.CG_Contrast;
+        cg.contrast.value = d.PPS_CG_Contrast;
 
         var vg = sp.GetSetting<Vignette>();
         if (vg == null) {
@@ -85,13 +85,13 @@ public class PostProcessingManager : MonoBehaviour
         }
         vg.active = true;
         vg.enabled.overrideState = true;
-        vg.enabled.value = d.Vignette_Enable;
+        vg.enabled.value = d.PPS_Vignette_Enable;
         vg.intensity.overrideState = true;
-        vg.intensity.value = d.Vignette_Intensity;
+        vg.intensity.value = d.PPS_Vignette_Intensity;
         vg.smoothness.overrideState = true;
-        vg.smoothness.value = d.Vignette_Smoothness;
+        vg.smoothness.value = d.PPS_Vignette_Smoothness;
         vg.roundness.overrideState = true;
-        vg.roundness.value = d.Vignette_Rounded;
+        vg.roundness.value = d.PPS_Vignette_Rounded;
 
         var ca = sp.GetSetting<ChromaticAberration>();
         if (ca == null) {
@@ -99,9 +99,9 @@ public class PostProcessingManager : MonoBehaviour
         }
         ca.active = true;
         ca.enabled.overrideState = true;
-        ca.enabled.value = d.CA_Enable;
+        ca.enabled.value = d.PPS_CA_Enable;
         ca.intensity.overrideState = true;
-        ca.intensity.value = d.CA_Intensity;
+        ca.intensity.value = d.PPS_CA_Intensity;
 
 
         postProcessVolume.sharedProfile = sp;

--- a/Assets/PostProcessingManager.cs
+++ b/Assets/PostProcessingManager.cs
@@ -10,26 +10,44 @@ public class PostProcessingManager : MonoBehaviour
     PostProcessVolume postProcessVolume;
     private void Start()
     {
-        postProcessVolume = GetComponent<PostProcessVolume>();
+        postProcessVolume = gameObject.AddComponent<PostProcessVolume>();
     }
 
     public void Apply(PipeCommands.SetPostProcessing d)
     {
+        postProcessVolume.isGlobal = true;
         var sp = postProcessVolume.sharedProfile;
+        if (sp == null) {
+            sp = ScriptableObject.CreateInstance<PostProcessProfile>();
+        }
 
         var bloom = sp.GetSetting<Bloom>();
+        if (bloom == null) {
+            bloom = sp.AddSettings<Bloom>();
+        }
         bloom.active = true;
+        bloom.enabled.overrideState = true;
         bloom.enabled.value = d.Bloom_Enable;
+        bloom.intensity.overrideState = true;
         bloom.intensity.value = d.Bloom_Intensity;
+        bloom.threshold.overrideState = true;
         bloom.threshold.value = d.Bloom_Threshold;
 
         var dof = sp.GetSetting<DepthOfField>();
+        if (dof == null) {
+            dof = sp.AddSettings<DepthOfField>();
+        }
         dof.active = true;
+        dof.enabled.overrideState = true;
         dof.enabled.value = d.DoF_Enable;
+        dof.focusDistance.overrideState = true;
         dof.focusDistance.value = d.DoF_FocusDistance;
+        dof.aperture.overrideState = true;
         dof.aperture.value = d.DoF_Aperture;
+        dof.focalLength.overrideState = true;
         dof.focalLength.value = d.DoF_FocusLength;
 
+        dof.kernelSize.overrideState = true;
         switch (d.DoF_MaxBlurSize) {
             case 0:
                 dof.kernelSize.value = KernelSize.Small;
@@ -50,21 +68,39 @@ public class PostProcessingManager : MonoBehaviour
 
 
         var cg = sp.GetSetting<ColorGrading>();
+        if (cg == null) {
+            cg = sp.AddSettings<ColorGrading>();
+        }
         cg.active = true;
+        cg.enabled.overrideState = true;
         cg.enabled.value = d.CG_Enable;
+        cg.saturation.overrideState = true;
         cg.saturation.value = d.CG_Saturation;
+        cg.contrast.overrideState = true;
         cg.contrast.value = d.CG_Contrast;
 
         var vg = sp.GetSetting<Vignette>();
+        if (vg == null) {
+            vg = sp.AddSettings<Vignette>();
+        }
         vg.active = true;
+        vg.enabled.overrideState = true;
         vg.enabled.value = d.Vignette_Enable;
+        vg.intensity.overrideState = true;
         vg.intensity.value = d.Vignette_Intensity;
+        vg.smoothness.overrideState = true;
         vg.smoothness.value = d.Vignette_Smoothness;
+        vg.roundness.overrideState = true;
         vg.roundness.value = d.Vignette_Rounded;
 
         var ca = sp.GetSetting<ChromaticAberration>();
+        if (ca == null) {
+            ca = sp.AddSettings<ChromaticAberration>();
+        }
         ca.active = true;
+        ca.enabled.overrideState = true;
         ca.enabled.value = d.CA_Enable;
+        ca.intensity.overrideState = true;
         ca.intensity.value = d.CA_Intensity;
 
 

--- a/Assets/PostProcessingManager.cs
+++ b/Assets/PostProcessingManager.cs
@@ -15,6 +15,8 @@ public class PostProcessingManager : MonoBehaviour
 
     public void Apply(ControlWPFWindow.Settings d)
     {
+        postProcessVolume.enabled = d.PPS_Enable;
+
         postProcessVolume.isGlobal = true;
         var sp = postProcessVolume.sharedProfile;
         if (sp == null) {
@@ -32,6 +34,10 @@ public class PostProcessingManager : MonoBehaviour
         bloom.intensity.value = d.PPS_Bloom_Intensity;
         bloom.threshold.overrideState = true;
         bloom.threshold.value = d.PPS_Bloom_Threshold;
+        bloom.fastMode.overrideState = true;
+        bloom.fastMode.value = true;
+        bloom.color.overrideState = true;
+        bloom.color.value = new Color(d.PPS_Bloom_Color_r, d.PPS_Bloom_Color_g, d.PPS_Bloom_Color_b, d.PPS_Bloom_Color_a);
 
         var dof = sp.GetSetting<DepthOfField>();
         if (dof == null) {
@@ -74,10 +80,16 @@ public class PostProcessingManager : MonoBehaviour
         cg.active = true;
         cg.enabled.overrideState = true;
         cg.enabled.value = d.PPS_CG_Enable;
+        cg.temperature.overrideState = true;
+        cg.temperature.value = d.PPS_CG_Temperature;
         cg.saturation.overrideState = true;
         cg.saturation.value = d.PPS_CG_Saturation;
         cg.contrast.overrideState = true;
         cg.contrast.value = d.PPS_CG_Contrast;
+        cg.gamma.overrideState = true;
+        cg.gamma.value = new Vector4(0,0,0, d.PPS_CG_Gamma);
+        cg.colorFilter.overrideState = true;
+        cg.colorFilter.value = new Color(d.PPS_CG_ColorFilter_r, d.PPS_CG_ColorFilter_g, d.PPS_CG_ColorFilter_b, d.PPS_CG_ColorFilter_a);
 
         var vg = sp.GetSetting<Vignette>();
         if (vg == null) {
@@ -91,7 +103,9 @@ public class PostProcessingManager : MonoBehaviour
         vg.smoothness.overrideState = true;
         vg.smoothness.value = d.PPS_Vignette_Smoothness;
         vg.roundness.overrideState = true;
-        vg.roundness.value = d.PPS_Vignette_Rounded;
+        vg.roundness.value = d.PPS_Vignette_Roundness;
+        vg.color.overrideState = true;
+        vg.color.value = new Color(d.PPS_Vignette_Color_r, d.PPS_Vignette_Color_g, d.PPS_Vignette_Color_b, d.PPS_Vignette_Color_a);
 
         var ca = sp.GetSetting<ChromaticAberration>();
         if (ca == null) {
@@ -102,6 +116,8 @@ public class PostProcessingManager : MonoBehaviour
         ca.enabled.value = d.PPS_CA_Enable;
         ca.intensity.overrideState = true;
         ca.intensity.value = d.PPS_CA_Intensity;
+        ca.fastMode.overrideState = true;
+        ca.fastMode.value = d.PPS_CA_FastMode;
 
 
         postProcessVolume.sharedProfile = sp;

--- a/Assets/PostProcessingManager.cs
+++ b/Assets/PostProcessingManager.cs
@@ -1,0 +1,75 @@
+﻿//gpsnmeajp
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityMemoryMappedFile;
+using UnityEngine.Rendering.PostProcessing;
+
+public class PostProcessingManager : MonoBehaviour
+{
+    PostProcessVolume postProcessVolume;
+    private void Start()
+    {
+        postProcessVolume = GetComponent<PostProcessVolume>();
+    }
+
+    public void Apply(PipeCommands.SetPostProcessing d)
+    {
+        var sp = postProcessVolume.sharedProfile;
+
+        var bloom = sp.GetSetting<Bloom>();
+        bloom.active = true;
+        bloom.enabled.value = d.Bloom_Enable;
+        bloom.intensity.value = d.Bloom_Intensity;
+        bloom.threshold.value = d.Bloom_Threshold;
+
+        var dof = sp.GetSetting<DepthOfField>();
+        dof.active = true;
+        dof.enabled.value = d.DoF_Enable;
+        dof.focusDistance.value = d.DoF_FocusDistance;
+        dof.aperture.value = d.DoF_Aperture;
+        dof.focalLength.value = d.DoF_FocusLength;
+
+        switch (d.DoF_MaxBlurSize) {
+            case 0:
+                dof.kernelSize.value = KernelSize.Small;
+                break;
+            case 1:
+                dof.kernelSize.value = KernelSize.Medium;
+                break;
+            case 2:
+                dof.kernelSize.value = KernelSize.Large;
+                break;
+            case 3:
+                dof.kernelSize.value = KernelSize.VeryLarge;
+                break;
+            default:
+                dof.kernelSize.value = KernelSize.Small;
+                break;
+        }
+
+
+        var cg = sp.GetSetting<ColorGrading>();
+        cg.active = true;
+        cg.enabled.value = d.CG_Enable;
+        cg.saturation.value = d.CG_Saturation;
+        cg.contrast.value = d.CG_Contrast;
+
+        var vg = sp.GetSetting<Vignette>();
+        vg.active = true;
+        vg.enabled.value = d.Vignette_Enable;
+        vg.intensity.value = d.Vignette_Intensity;
+        vg.smoothness.value = d.Vignette_Smoothness;
+        vg.roundness.value = d.Vignette_Rounded;
+
+        var ca = sp.GetSetting<ChromaticAberration>();
+        ca.active = true;
+        ca.enabled.value = d.CA_Enable;
+        ca.intensity.value = d.CA_Intensity;
+
+
+        postProcessVolume.sharedProfile = sp;
+
+
+    }
+}

--- a/Assets/Scripts/ControlWPFWindow.cs
+++ b/Assets/Scripts/ControlWPFWindow.cs
@@ -952,11 +952,62 @@ public class ControlWPFWindow : MonoBehaviour
             }
             else if (e.CommandType == typeof(PipeCommands.GetPostProcessing))
             {
-                //TODO
+                await server.SendCommandAsync(new PipeCommands.SetPostProcessing {
+                    PPS_Enable = CurrentSettings.PPS_Enable,
+
+                    Bloom_Enable = CurrentSettings.PPS_Bloom_Enable,
+                    Bloom_Intensity = CurrentSettings.PPS_Bloom_Intensity,
+                    Bloom_Threshold = CurrentSettings.PPS_Bloom_Threshold,
+
+                    DoF_Enable = CurrentSettings.PPS_DoF_Enable,
+                    DoF_FocusDistance = CurrentSettings.PPS_DoF_FocusDistance,
+                    DoF_Aperture = CurrentSettings.PPS_DoF_Aperture,
+                    DoF_FocusLength = CurrentSettings.PPS_DoF_FocusLength,
+                    DoF_MaxBlurSize = CurrentSettings.PPS_DoF_MaxBlurSize,
+
+                    CG_Enable = CurrentSettings.PPS_CG_Enable,
+                    CG_Temperature = CurrentSettings.PPS_CG_Temperature,
+                    CG_Saturation = CurrentSettings.PPS_CG_Saturation,
+                    CG_Contrast = CurrentSettings.PPS_CG_Contrast,
+
+                    Vignette_Enable = CurrentSettings.PPS_Vignette_Enable,
+                    Vignette_Intensity = CurrentSettings.PPS_Vignette_Intensity,
+                    Vignette_Smoothness = CurrentSettings.PPS_Vignette_Smoothness,
+                    Vignette_Rounded = CurrentSettings.PPS_Vignette_Rounded,
+
+                    CA_Enable = CurrentSettings.PPS_CA_Enable,
+                    CA_Intensity = CurrentSettings.PPS_CA_Intensity,
+                });
             }
             else if (e.CommandType == typeof(PipeCommands.SetPostProcessing)) {
                 var d = (PipeCommands.SetPostProcessing)e.Data;
-                postProcessingManager.Apply(d);
+
+                CurrentSettings.PPS_Enable = d.PPS_Enable;
+
+                CurrentSettings.PPS_Bloom_Enable = d.Bloom_Enable;
+                CurrentSettings.PPS_Bloom_Intensity = d.Bloom_Intensity;
+                CurrentSettings.PPS_Bloom_Threshold = d.Bloom_Threshold;
+
+                CurrentSettings.PPS_DoF_Enable = d.DoF_Enable;
+                CurrentSettings.PPS_DoF_FocusDistance = d.DoF_FocusDistance;
+                CurrentSettings.PPS_DoF_Aperture = d.DoF_Aperture;
+                CurrentSettings.PPS_DoF_FocusLength = d.DoF_FocusLength;
+                CurrentSettings.PPS_DoF_MaxBlurSize = d.DoF_MaxBlurSize;
+
+                CurrentSettings.PPS_CG_Enable = d.CG_Enable;
+                CurrentSettings.PPS_CG_Temperature = d.CG_Temperature;
+                CurrentSettings.PPS_CG_Saturation = d.CG_Saturation;
+                CurrentSettings.PPS_CG_Contrast = d.CG_Contrast;
+
+                CurrentSettings.PPS_Vignette_Enable = d.Vignette_Enable;
+                CurrentSettings.PPS_Vignette_Intensity = d.Vignette_Intensity;
+                CurrentSettings.PPS_Vignette_Smoothness = d.Vignette_Smoothness;
+                CurrentSettings.PPS_Vignette_Rounded = d.Vignette_Rounded;
+
+                CurrentSettings.PPS_CA_Enable = d.CA_Enable;
+                CurrentSettings.PPS_CA_Intensity = d.CA_Intensity;
+
+                postProcessingManager.Apply(CurrentSettings);
             }
             else if (e.CommandType == typeof(PipeCommands.Alive))
             {
@@ -2917,6 +2968,50 @@ public class ControlWPFWindow : MonoBehaviour
         [OptionalField]
         public int VirtualMotionTrackerNo;
 
+
+        [OptionalField]
+        public bool PPS_Enable;
+        [OptionalField]
+        public bool PPS_Bloom_Enable;
+        [OptionalField]
+        public float PPS_Bloom_Intensity;
+        [OptionalField]
+        public float PPS_Bloom_Threshold;
+
+        [OptionalField]
+        public bool PPS_DoF_Enable;
+        [OptionalField]
+        public float PPS_DoF_FocusDistance;
+        [OptionalField]
+        public float PPS_DoF_Aperture;
+        [OptionalField]
+        public float PPS_DoF_FocusLength;
+        [OptionalField]
+        public int PPS_DoF_MaxBlurSize;
+
+        [OptionalField]
+        public bool PPS_CG_Enable;
+        [OptionalField]
+        public float PPS_CG_Temperature;
+        [OptionalField]
+        public float PPS_CG_Saturation;
+        [OptionalField]
+        public float PPS_CG_Contrast;
+
+        [OptionalField]
+        public bool PPS_Vignette_Enable;
+        [OptionalField]
+        public float PPS_Vignette_Intensity;
+        [OptionalField]
+        public float PPS_Vignette_Smoothness;
+        [OptionalField]
+        public float PPS_Vignette_Rounded;
+
+        [OptionalField]
+        public bool PPS_CA_Enable;
+        [OptionalField]
+        public float PPS_CA_Intensity;
+
         //初期値
         [OnDeserializing()]
         internal void OnDeserializingMethod(StreamingContext context)
@@ -3005,6 +3100,31 @@ public class ControlWPFWindow : MonoBehaviour
 
             VirtualMotionTrackerEnable = false;
             VirtualMotionTrackerNo = 50;
+
+            PPS_Enable = false;
+            PPS_Bloom_Enable = false;
+            PPS_Bloom_Intensity = 0f;
+            PPS_Bloom_Threshold = 0f;
+
+            PPS_DoF_Enable = false;
+            PPS_DoF_FocusDistance = 0f;
+            PPS_DoF_Aperture = 0f;
+            PPS_DoF_FocusLength = 0f;
+            PPS_DoF_MaxBlurSize = 0;
+
+            PPS_CG_Enable = false;
+            PPS_CG_Temperature = 0f;
+            PPS_CG_Saturation = 0f;
+            PPS_CG_Contrast = 0f;
+
+            PPS_Vignette_Enable = false;
+            PPS_Vignette_Intensity = 0f;
+            PPS_Vignette_Smoothness = 0f;
+            PPS_Vignette_Rounded = 0f;
+
+            PPS_CA_Enable = false;
+            PPS_CA_Intensity = 0f;
+
         }
     }
 
@@ -3382,6 +3502,8 @@ public class ControlWPFWindow : MonoBehaviour
         SetVMT(CurrentSettings.VirtualMotionTrackerEnable, CurrentSettings.VirtualMotionTrackerNo);
 
         SetLipShapeToBlendShapeStringMapAction?.Invoke(CurrentSettings.LipShapesToBlendShapeMap);
+
+        postProcessingManager.Apply(CurrentSettings);
 
         AdditionalSettingAction?.Invoke(null);
 

--- a/Assets/Scripts/ControlWPFWindow.cs
+++ b/Assets/Scripts/ControlWPFWindow.cs
@@ -952,50 +952,7 @@ public class ControlWPFWindow : MonoBehaviour
             }
             else if (e.CommandType == typeof(PipeCommands.GetAdvancedGraphicsOption))
             {
-                await server.SendCommandAsync(new PipeCommands.SetAdvancedGraphicsOption
-                {
-                    PPS_Enable = CurrentSettings.PPS_Enable,
-
-                    Bloom_Enable = CurrentSettings.PPS_Bloom_Enable,
-                    Bloom_Intensity = CurrentSettings.PPS_Bloom_Intensity,
-                    Bloom_Threshold = CurrentSettings.PPS_Bloom_Threshold,
-
-                    DoF_Enable = CurrentSettings.PPS_DoF_Enable,
-                    DoF_FocusDistance = CurrentSettings.PPS_DoF_FocusDistance,
-                    DoF_Aperture = CurrentSettings.PPS_DoF_Aperture,
-                    DoF_FocusLength = CurrentSettings.PPS_DoF_FocusLength,
-                    DoF_MaxBlurSize = CurrentSettings.PPS_DoF_MaxBlurSize,
-
-                    CG_Enable = CurrentSettings.PPS_CG_Enable,
-                    CG_Temperature = CurrentSettings.PPS_CG_Temperature,
-                    CG_Saturation = CurrentSettings.PPS_CG_Saturation,
-                    CG_Contrast = CurrentSettings.PPS_CG_Contrast,
-                    CG_Gamma = CurrentSettings.PPS_CG_Gamma,
-
-                    Vignette_Enable = CurrentSettings.PPS_Vignette_Enable,
-                    Vignette_Intensity = CurrentSettings.PPS_Vignette_Intensity,
-                    Vignette_Smoothness = CurrentSettings.PPS_Vignette_Smoothness,
-                    Vignette_Roundness = CurrentSettings.PPS_Vignette_Roundness,
-
-                    CA_Enable = CurrentSettings.PPS_CA_Enable,
-                    CA_Intensity = CurrentSettings.PPS_CA_Intensity,
-                    CA_FastMode = CurrentSettings.PPS_CA_FastMode,
-
-                    Bloom_Color_a = CurrentSettings.PPS_Bloom_Color_a,
-                    Bloom_Color_r = CurrentSettings.PPS_Bloom_Color_r,
-                    Bloom_Color_g = CurrentSettings.PPS_Bloom_Color_g,
-                    Bloom_Color_b = CurrentSettings.PPS_Bloom_Color_b,
-
-                    CG_ColorFilter_a = CurrentSettings.PPS_CG_ColorFilter_a,
-                    CG_ColorFilter_r = CurrentSettings.PPS_CG_ColorFilter_r,
-                    CG_ColorFilter_g = CurrentSettings.PPS_CG_ColorFilter_g,
-                    CG_ColorFilter_b = CurrentSettings.PPS_CG_ColorFilter_b,
-
-                    Vignette_Color_a = CurrentSettings.PPS_Vignette_Color_a,
-                    Vignette_Color_r = CurrentSettings.PPS_Vignette_Color_r,
-                    Vignette_Color_g = CurrentSettings.PPS_Vignette_Color_g,
-                    Vignette_Color_b = CurrentSettings.PPS_Vignette_Color_b,
-                });
+                LoadAdvancedGraphicsOption();
             }
             else if (e.CommandType == typeof(PipeCommands.SetAdvancedGraphicsOption)) {
                 var d = (PipeCommands.SetAdvancedGraphicsOption)e.Data;
@@ -1091,6 +1048,55 @@ public class ControlWPFWindow : MonoBehaviour
 
         CurrentSettings.VirtualMotionTrackerNo = no;
         CurrentSettings.VirtualMotionTrackerEnable = enable;
+    }
+
+    private async void LoadAdvancedGraphicsOption()
+    {
+        SetAdvancedGraphicsOption();
+        await server.SendCommandAsync(new PipeCommands.SetAdvancedGraphicsOption
+        {
+            PPS_Enable = CurrentSettings.PPS_Enable,
+
+            Bloom_Enable = CurrentSettings.PPS_Bloom_Enable,
+            Bloom_Intensity = CurrentSettings.PPS_Bloom_Intensity,
+            Bloom_Threshold = CurrentSettings.PPS_Bloom_Threshold,
+
+            DoF_Enable = CurrentSettings.PPS_DoF_Enable,
+            DoF_FocusDistance = CurrentSettings.PPS_DoF_FocusDistance,
+            DoF_Aperture = CurrentSettings.PPS_DoF_Aperture,
+            DoF_FocusLength = CurrentSettings.PPS_DoF_FocusLength,
+            DoF_MaxBlurSize = CurrentSettings.PPS_DoF_MaxBlurSize,
+
+            CG_Enable = CurrentSettings.PPS_CG_Enable,
+            CG_Temperature = CurrentSettings.PPS_CG_Temperature,
+            CG_Saturation = CurrentSettings.PPS_CG_Saturation,
+            CG_Contrast = CurrentSettings.PPS_CG_Contrast,
+            CG_Gamma = CurrentSettings.PPS_CG_Gamma,
+
+            Vignette_Enable = CurrentSettings.PPS_Vignette_Enable,
+            Vignette_Intensity = CurrentSettings.PPS_Vignette_Intensity,
+            Vignette_Smoothness = CurrentSettings.PPS_Vignette_Smoothness,
+            Vignette_Roundness = CurrentSettings.PPS_Vignette_Roundness,
+
+            CA_Enable = CurrentSettings.PPS_CA_Enable,
+            CA_Intensity = CurrentSettings.PPS_CA_Intensity,
+            CA_FastMode = CurrentSettings.PPS_CA_FastMode,
+
+            Bloom_Color_a = CurrentSettings.PPS_Bloom_Color_a,
+            Bloom_Color_r = CurrentSettings.PPS_Bloom_Color_r,
+            Bloom_Color_g = CurrentSettings.PPS_Bloom_Color_g,
+            Bloom_Color_b = CurrentSettings.PPS_Bloom_Color_b,
+
+            CG_ColorFilter_a = CurrentSettings.PPS_CG_ColorFilter_a,
+            CG_ColorFilter_r = CurrentSettings.PPS_CG_ColorFilter_r,
+            CG_ColorFilter_g = CurrentSettings.PPS_CG_ColorFilter_g,
+            CG_ColorFilter_b = CurrentSettings.PPS_CG_ColorFilter_b,
+
+            Vignette_Color_a = CurrentSettings.PPS_Vignette_Color_a,
+            Vignette_Color_r = CurrentSettings.PPS_Vignette_Color_r,
+            Vignette_Color_g = CurrentSettings.PPS_Vignette_Color_g,
+            Vignette_Color_b = CurrentSettings.PPS_Vignette_Color_b,
+        });
     }
 
     private void SetAdvancedGraphicsOption() {
@@ -3173,28 +3179,28 @@ public class ControlWPFWindow : MonoBehaviour
 
             PPS_Enable = false;
             PPS_Bloom_Enable = false;
-            PPS_Bloom_Intensity = 0f;
-            PPS_Bloom_Threshold = 0f;
+            PPS_Bloom_Intensity = 2.7f;
+            PPS_Bloom_Threshold = 0.5f;
 
             PPS_DoF_Enable = false;
-            PPS_DoF_FocusDistance = 0f;
-            PPS_DoF_Aperture = 0f;
-            PPS_DoF_FocusLength = 0f;
-            PPS_DoF_MaxBlurSize = 0;
+            PPS_DoF_FocusDistance = 1.65f;
+            PPS_DoF_Aperture = 16f;
+            PPS_DoF_FocusLength = 16.4f;
+            PPS_DoF_MaxBlurSize = 3;
 
             PPS_CG_Enable = false;
             PPS_CG_Temperature = 0f;
             PPS_CG_Saturation = 0f;
             PPS_CG_Contrast = 0f;
-            PPS_CG_Gamma = 1.0f;
+            PPS_CG_Gamma = 0f;
 
             PPS_Vignette_Enable = false;
-            PPS_Vignette_Intensity = 0f;
-            PPS_Vignette_Smoothness = 0f;
-            PPS_Vignette_Roundness = 0f;
+            PPS_Vignette_Intensity = 0.65f;
+            PPS_Vignette_Smoothness = 0.35f;
+            PPS_Vignette_Roundness = 1f;
 
             PPS_CA_Enable = false;
-            PPS_CA_Intensity = 0f;
+            PPS_CA_Intensity = 1f;
             PPS_CA_FastMode = false;
 
             PPS_Bloom_Color_a = 1f;
@@ -3589,7 +3595,7 @@ public class ControlWPFWindow : MonoBehaviour
 
         SetLipShapeToBlendShapeStringMapAction?.Invoke(CurrentSettings.LipShapesToBlendShapeMap);
 
-        SetAdvancedGraphicsOption();
+        LoadAdvancedGraphicsOption();
 
         AdditionalSettingAction?.Invoke(null);
 

--- a/Assets/Scripts/ControlWPFWindow.cs
+++ b/Assets/Scripts/ControlWPFWindow.cs
@@ -81,6 +81,8 @@ public class ControlWPFWindow : MonoBehaviour
 
     public VMTClient vmtClient;
 
+    public PostProcessingManager postProcessingManager;
+
     public enum MouseButtons
     {
         Left = 0,
@@ -929,7 +931,7 @@ public class ControlWPFWindow : MonoBehaviour
                 await server.SendCommandAsync(new PipeCommands.ResultSetupVirtualMotionTracker
                 {
                     result = ret,
-                }, e.RequestId);                
+                }, e.RequestId);
             }
             else if (e.CommandType == typeof(PipeCommands.GetViveLipTrackingBlendShape))
             {
@@ -947,6 +949,14 @@ public class ControlWPFWindow : MonoBehaviour
                 var d = (PipeCommands.SetViveLipTrackingBlendShape)e.Data;
                 CurrentSettings.LipShapesToBlendShapeMap = d.LipShapesToBlendShapeMap;
                 SetLipShapeToBlendShapeStringMapAction?.Invoke(d.LipShapesToBlendShapeMap);
+            }
+            else if (e.CommandType == typeof(PipeCommands.GetPostProcessing))
+            {
+                //TODO
+            }
+            else if (e.CommandType == typeof(PipeCommands.SetPostProcessing)) {
+                var d = (PipeCommands.SetPostProcessing)e.Data;
+                postProcessingManager.Apply(d);
             }
             else if (e.CommandType == typeof(PipeCommands.Alive))
             {

--- a/Assets/Scripts/ControlWPFWindow.cs
+++ b/Assets/Scripts/ControlWPFWindow.cs
@@ -999,6 +999,8 @@ public class ControlWPFWindow : MonoBehaviour
                 CurrentSettings.PPS_Vignette_Color_g = d.Vignette_Color_g;
                 CurrentSettings.PPS_Vignette_Color_b = d.Vignette_Color_b;
 
+                CurrentSettings.TurnOffAmbientLight = d.TurnOffAmbientLight;
+
                 SetAdvancedGraphicsOption();
             }
             else if (e.CommandType == typeof(PipeCommands.Alive))
@@ -1096,7 +1098,9 @@ public class ControlWPFWindow : MonoBehaviour
             Vignette_Color_r = CurrentSettings.PPS_Vignette_Color_r,
             Vignette_Color_g = CurrentSettings.PPS_Vignette_Color_g,
             Vignette_Color_b = CurrentSettings.PPS_Vignette_Color_b,
-        });
+
+            TurnOffAmbientLight = CurrentSettings.TurnOffAmbientLight
+    });
     }
 
     private void SetAdvancedGraphicsOption() {
@@ -3088,6 +3092,9 @@ public class ControlWPFWindow : MonoBehaviour
         [OptionalField]
         public float PPS_Vignette_Color_b;
 
+        [OptionalField]
+        public bool TurnOffAmbientLight;
+
         //初期値
         [OnDeserializing()]
         internal void OnDeserializingMethod(StreamingContext context)
@@ -3217,6 +3224,8 @@ public class ControlWPFWindow : MonoBehaviour
             PPS_Vignette_Color_r = 0f;
             PPS_Vignette_Color_g = 0f;
             PPS_Vignette_Color_b = 0f;
+
+            TurnOffAmbientLight = false;
         }
     }
 

--- a/Assets/Scripts/ControlWPFWindow.cs
+++ b/Assets/Scripts/ControlWPFWindow.cs
@@ -950,9 +950,10 @@ public class ControlWPFWindow : MonoBehaviour
                 CurrentSettings.LipShapesToBlendShapeMap = d.LipShapesToBlendShapeMap;
                 SetLipShapeToBlendShapeStringMapAction?.Invoke(d.LipShapesToBlendShapeMap);
             }
-            else if (e.CommandType == typeof(PipeCommands.GetPostProcessing))
+            else if (e.CommandType == typeof(PipeCommands.GetAdvancedGraphicsOption))
             {
-                await server.SendCommandAsync(new PipeCommands.SetPostProcessing {
+                await server.SendCommandAsync(new PipeCommands.SetAdvancedGraphicsOption
+                {
                     PPS_Enable = CurrentSettings.PPS_Enable,
 
                     Bloom_Enable = CurrentSettings.PPS_Bloom_Enable,
@@ -969,18 +970,35 @@ public class ControlWPFWindow : MonoBehaviour
                     CG_Temperature = CurrentSettings.PPS_CG_Temperature,
                     CG_Saturation = CurrentSettings.PPS_CG_Saturation,
                     CG_Contrast = CurrentSettings.PPS_CG_Contrast,
+                    CG_Gamma = CurrentSettings.PPS_CG_Gamma,
 
                     Vignette_Enable = CurrentSettings.PPS_Vignette_Enable,
                     Vignette_Intensity = CurrentSettings.PPS_Vignette_Intensity,
                     Vignette_Smoothness = CurrentSettings.PPS_Vignette_Smoothness,
-                    Vignette_Rounded = CurrentSettings.PPS_Vignette_Rounded,
+                    Vignette_Roundness = CurrentSettings.PPS_Vignette_Roundness,
 
                     CA_Enable = CurrentSettings.PPS_CA_Enable,
                     CA_Intensity = CurrentSettings.PPS_CA_Intensity,
+                    CA_FastMode = CurrentSettings.PPS_CA_FastMode,
+
+                    Bloom_Color_a = CurrentSettings.PPS_Bloom_Color_a,
+                    Bloom_Color_r = CurrentSettings.PPS_Bloom_Color_r,
+                    Bloom_Color_g = CurrentSettings.PPS_Bloom_Color_g,
+                    Bloom_Color_b = CurrentSettings.PPS_Bloom_Color_b,
+
+                    CG_ColorFilter_a = CurrentSettings.PPS_CG_ColorFilter_a,
+                    CG_ColorFilter_r = CurrentSettings.PPS_CG_ColorFilter_r,
+                    CG_ColorFilter_g = CurrentSettings.PPS_CG_ColorFilter_g,
+                    CG_ColorFilter_b = CurrentSettings.PPS_CG_ColorFilter_b,
+
+                    Vignette_Color_a = CurrentSettings.PPS_Vignette_Color_a,
+                    Vignette_Color_r = CurrentSettings.PPS_Vignette_Color_r,
+                    Vignette_Color_g = CurrentSettings.PPS_Vignette_Color_g,
+                    Vignette_Color_b = CurrentSettings.PPS_Vignette_Color_b,
                 });
             }
-            else if (e.CommandType == typeof(PipeCommands.SetPostProcessing)) {
-                var d = (PipeCommands.SetPostProcessing)e.Data;
+            else if (e.CommandType == typeof(PipeCommands.SetAdvancedGraphicsOption)) {
+                var d = (PipeCommands.SetAdvancedGraphicsOption)e.Data;
 
                 CurrentSettings.PPS_Enable = d.PPS_Enable;
 
@@ -998,16 +1016,33 @@ public class ControlWPFWindow : MonoBehaviour
                 CurrentSettings.PPS_CG_Temperature = d.CG_Temperature;
                 CurrentSettings.PPS_CG_Saturation = d.CG_Saturation;
                 CurrentSettings.PPS_CG_Contrast = d.CG_Contrast;
+                CurrentSettings.PPS_CG_Gamma = d.CG_Gamma;
 
                 CurrentSettings.PPS_Vignette_Enable = d.Vignette_Enable;
                 CurrentSettings.PPS_Vignette_Intensity = d.Vignette_Intensity;
                 CurrentSettings.PPS_Vignette_Smoothness = d.Vignette_Smoothness;
-                CurrentSettings.PPS_Vignette_Rounded = d.Vignette_Rounded;
+                CurrentSettings.PPS_Vignette_Roundness = d.Vignette_Roundness;
 
                 CurrentSettings.PPS_CA_Enable = d.CA_Enable;
                 CurrentSettings.PPS_CA_Intensity = d.CA_Intensity;
+                CurrentSettings.PPS_CA_FastMode = d.CA_FastMode;
 
-                postProcessingManager.Apply(CurrentSettings);
+                CurrentSettings.PPS_Bloom_Color_a = d.Bloom_Color_a;
+                CurrentSettings.PPS_Bloom_Color_r = d.Bloom_Color_r;
+                CurrentSettings.PPS_Bloom_Color_g = d.Bloom_Color_g;
+                CurrentSettings.PPS_Bloom_Color_b = d.Bloom_Color_b;
+
+                CurrentSettings.PPS_CG_ColorFilter_a = d.CG_ColorFilter_a;
+                CurrentSettings.PPS_CG_ColorFilter_r = d.CG_ColorFilter_r;
+                CurrentSettings.PPS_CG_ColorFilter_g = d.CG_ColorFilter_g;
+                CurrentSettings.PPS_CG_ColorFilter_b = d.CG_ColorFilter_b;
+
+                CurrentSettings.PPS_Vignette_Color_a = d.Vignette_Color_a;
+                CurrentSettings.PPS_Vignette_Color_r = d.Vignette_Color_r;
+                CurrentSettings.PPS_Vignette_Color_g = d.Vignette_Color_g;
+                CurrentSettings.PPS_Vignette_Color_b = d.Vignette_Color_b;
+
+                SetAdvancedGraphicsOption();
             }
             else if (e.CommandType == typeof(PipeCommands.Alive))
             {
@@ -1056,6 +1091,10 @@ public class ControlWPFWindow : MonoBehaviour
 
         CurrentSettings.VirtualMotionTrackerNo = no;
         CurrentSettings.VirtualMotionTrackerEnable = enable;
+    }
+
+    private void SetAdvancedGraphicsOption() {
+        postProcessingManager.Apply(CurrentSettings);
     }
 
     private bool isFirstTimeExecute = true;
@@ -2997,6 +3036,8 @@ public class ControlWPFWindow : MonoBehaviour
         public float PPS_CG_Saturation;
         [OptionalField]
         public float PPS_CG_Contrast;
+        [OptionalField]
+        public float PPS_CG_Gamma;
 
         [OptionalField]
         public bool PPS_Vignette_Enable;
@@ -3005,12 +3046,41 @@ public class ControlWPFWindow : MonoBehaviour
         [OptionalField]
         public float PPS_Vignette_Smoothness;
         [OptionalField]
-        public float PPS_Vignette_Rounded;
+        public float PPS_Vignette_Roundness;
 
         [OptionalField]
         public bool PPS_CA_Enable;
         [OptionalField]
         public float PPS_CA_Intensity;
+        [OptionalField]
+        public bool PPS_CA_FastMode;
+
+        [OptionalField]
+        public float PPS_Bloom_Color_a;
+        [OptionalField]
+        public float PPS_Bloom_Color_r;
+        [OptionalField]
+        public float PPS_Bloom_Color_g;
+        [OptionalField]
+        public float PPS_Bloom_Color_b;
+
+        [OptionalField]
+        public float PPS_CG_ColorFilter_a;
+        [OptionalField]
+        public float PPS_CG_ColorFilter_r;
+        [OptionalField]
+        public float PPS_CG_ColorFilter_g;
+        [OptionalField]
+        public float PPS_CG_ColorFilter_b;
+
+        [OptionalField]
+        public float PPS_Vignette_Color_a;
+        [OptionalField]
+        public float PPS_Vignette_Color_r;
+        [OptionalField]
+        public float PPS_Vignette_Color_g;
+        [OptionalField]
+        public float PPS_Vignette_Color_b;
 
         //初期値
         [OnDeserializing()]
@@ -3116,15 +3186,31 @@ public class ControlWPFWindow : MonoBehaviour
             PPS_CG_Temperature = 0f;
             PPS_CG_Saturation = 0f;
             PPS_CG_Contrast = 0f;
+            PPS_CG_Gamma = 1.0f;
 
             PPS_Vignette_Enable = false;
             PPS_Vignette_Intensity = 0f;
             PPS_Vignette_Smoothness = 0f;
-            PPS_Vignette_Rounded = 0f;
+            PPS_Vignette_Roundness = 0f;
 
             PPS_CA_Enable = false;
             PPS_CA_Intensity = 0f;
+            PPS_CA_FastMode = false;
 
+            PPS_Bloom_Color_a = 1f;
+            PPS_Bloom_Color_r = 1f;
+            PPS_Bloom_Color_g = 1f;
+            PPS_Bloom_Color_b = 1f;
+
+            PPS_CG_ColorFilter_a = 1f;
+            PPS_CG_ColorFilter_r = 1f;
+            PPS_CG_ColorFilter_g = 1f;
+            PPS_CG_ColorFilter_b = 1f;
+
+            PPS_Vignette_Color_a = 1f;
+            PPS_Vignette_Color_r = 0f;
+            PPS_Vignette_Color_g = 0f;
+            PPS_Vignette_Color_b = 0f;
         }
     }
 
@@ -3503,7 +3589,7 @@ public class ControlWPFWindow : MonoBehaviour
 
         SetLipShapeToBlendShapeStringMapAction?.Invoke(CurrentSettings.LipShapesToBlendShapeMap);
 
-        postProcessingManager.Apply(CurrentSettings);
+        SetAdvancedGraphicsOption();
 
         AdditionalSettingAction?.Invoke(null);
 

--- a/ControlWindowWPF/ControlWindowWPF/GraphicsOptionWindow.xaml
+++ b/ControlWindowWPF/ControlWindowWPF/GraphicsOptionWindow.xaml
@@ -128,6 +128,12 @@
 				</GroupBox>
 			</DockPanel>
 		</GroupBox>
-
+		<GroupBox Header="Other" DockPanel.Dock="Top">
+			<DockPanel DockPanel.Dock="Top" LastChildFill="True">
+				<DockPanel DockPanel.Dock="Top" LastChildFill="False">
+					<CheckBox Name="TurnOffAmbientLight_CheckBox" Content="Turn OFF Ambient Light" DockPanel.Dock="Left" Checked="Checked" Unchecked="Checked"/>
+				</DockPanel>
+			</DockPanel>
+		</GroupBox>
 	</DockPanel>
 </Window>

--- a/ControlWindowWPF/ControlWindowWPF/GraphicsOptionWindow.xaml
+++ b/ControlWindowWPF/ControlWindowWPF/GraphicsOptionWindow.xaml
@@ -8,7 +8,7 @@
         Title="Graphics Option" Width="400" SizeToContent="Height" Loaded="Window_Loaded" Closing="Window_Closing">
 	<DockPanel LastChildFill="False" Margin="5">
 		
-		<GroupBox Header="Anti-aliasing" DockPanel.Dock="Top">
+		<GroupBox Header="Anti-aliasing" DockPanel.Dock="Top" Visibility="Collapsed">
 			<DockPanel DockPanel.Dock="Top" LastChildFill="False">
 				<DockPanel DockPanel.Dock="Top" LastChildFill="False">
 					<CheckBox Name="AntiAliasing_Enable_CheckBox" Content="Enable" DockPanel.Dock="Left" Checked="Checked" Unchecked="Checked"/>

--- a/ControlWindowWPF/ControlWindowWPF/GraphicsOptionWindow.xaml
+++ b/ControlWindowWPF/ControlWindowWPF/GraphicsOptionWindow.xaml
@@ -7,109 +7,125 @@
         mc:Ignorable="d"
         Title="Graphics Option" Width="400" SizeToContent="Height" Loaded="Window_Loaded" Closing="Window_Closing">
 	<DockPanel LastChildFill="False" Margin="5">
-		
-		<GroupBox Header="Anti-aliasing" DockPanel.Dock="Top" Visibility="Collapsed">
-			<DockPanel DockPanel.Dock="Top" LastChildFill="False">
-				<DockPanel DockPanel.Dock="Top" LastChildFill="False">
-					<CheckBox Name="AntiAliasing_Enable_CheckBox" Content="Enable" DockPanel.Dock="Left" Checked="Checked" Unchecked="Checked"/>
-				</DockPanel>
-			</DockPanel>
-		</GroupBox>
-		
-		<GroupBox Header="Bloom" DockPanel.Dock="Top">
-			<DockPanel DockPanel.Dock="Top" LastChildFill="False">
-				<DockPanel DockPanel.Dock="Top" LastChildFill="False">
-					<CheckBox Name="Bloom_Enable_CheckBox" Content="Enable" DockPanel.Dock="Left" Checked="Checked" Unchecked="Checked"/>
-					<Button Content="Reset" DockPanel.Dock="Right" Height="Auto" />
-				</DockPanel>
-				<DockPanel DockPanel.Dock="Top" LastChildFill="False">
-					<TextBlock Text="Intensity" DockPanel.Dock="Left"/>
-					<Slider Name="Bloom_Intensity_Slider" DockPanel.Dock="Right" HorizontalAlignment="Right" Width="200" Value="0" Minimum="0" Maximum="10" TickFrequency="0.01" ValueChanged="SliverValueChanged"/>
-				</DockPanel>
-				<DockPanel DockPanel.Dock="Top" LastChildFill="False">
-					<TextBlock Text="Threshold" DockPanel.Dock="Left"/>
-					<Slider Name="Bloom_Threshold_Slider" DockPanel.Dock="Right" HorizontalAlignment="Right" Width="200" Value="0" Minimum="0" Maximum="1.5" TickFrequency="0.01" ValueChanged="SliverValueChanged"/>
-				</DockPanel>
-			</DockPanel>
-		</GroupBox>
-		
-		<GroupBox Header="Depth of Field" DockPanel.Dock="Top">
-			<DockPanel DockPanel.Dock="Top" LastChildFill="False">
-				<DockPanel DockPanel.Dock="Top" LastChildFill="False">
-					<CheckBox Name="DoF_Enable_CheckBox" Content="Enable" DockPanel.Dock="Left" Checked="Checked" Unchecked="Checked"/>
-					<Button Content="Reset" DockPanel.Dock="Right" Height="Auto" />
-				</DockPanel>
-				<DockPanel DockPanel.Dock="Top" LastChildFill="False">
-					<TextBlock Text="Focus Distance" DockPanel.Dock="Left"/>
-					<Slider Name="DoF_FocusDistance_Slider" DockPanel.Dock="Right" HorizontalAlignment="Right" Width="200" Value="0" Minimum="0" Maximum="100" TickFrequency="0.01" ValueChanged="SliverValueChanged"/>
-				</DockPanel>
-				<DockPanel DockPanel.Dock="Top" LastChildFill="False">
-					<TextBlock Text="Aperture" DockPanel.Dock="Left"/>
-					<Slider Name="DoF_Aperture_Slider" DockPanel.Dock="Right" HorizontalAlignment="Right" Width="200" Value="0" Minimum="0" Maximum="32" TickFrequency="0.01" ValueChanged="SliverValueChanged"/>
-				</DockPanel>
-				<DockPanel DockPanel.Dock="Top" LastChildFill="False">
-					<TextBlock Text="Focus Length" DockPanel.Dock="Left"/>
-					<Slider Name="DoF_FocusLength_Slider" DockPanel.Dock="Right" HorizontalAlignment="Right" Width="200" Value="0" Minimum="0" Maximum="300" TickFrequency="0.01" ValueChanged="SliverValueChanged"/>
-				</DockPanel>
-				<DockPanel DockPanel.Dock="Top" LastChildFill="False">
-					<TextBlock Text="Max Blur Size" DockPanel.Dock="Left"/>
-					<Slider Name="DoF_MaxBlurSize_Slider" DockPanel.Dock="Right" HorizontalAlignment="Right" Width="200" Value="0" Minimum="0" Maximum="3" TickFrequency="1" IsSnapToTickEnabled="True" ValueChanged="SliverValueChanged"/>
-				</DockPanel>
-			</DockPanel>
-		</GroupBox>
 
-		<GroupBox Header="Color Grading" DockPanel.Dock="Top">
-			<DockPanel DockPanel.Dock="Top" LastChildFill="False">
+		<GroupBox Header="PostProcessing" DockPanel.Dock="Top">
+			<DockPanel DockPanel.Dock="Top" LastChildFill="True">
 				<DockPanel DockPanel.Dock="Top" LastChildFill="False">
-					<CheckBox Name="CG_Enable_CheckBox" Content="Enable" DockPanel.Dock="Left" Checked="Checked" Unchecked="Checked"/>
-					<Button Content="Reset" DockPanel.Dock="Right" Height="Auto" />
+					<CheckBox Name="Global_Enable_CheckBox" Content="Enable" DockPanel.Dock="Left" Checked="Checked" Unchecked="Checked"/>
 				</DockPanel>
-				<DockPanel DockPanel.Dock="Top" LastChildFill="False">
-					<TextBlock Text="Temperature" DockPanel.Dock="Left"/>
-					<Slider Name="CG_Temperature_Slider" DockPanel.Dock="Right" HorizontalAlignment="Right" Width="200" Value="0" Minimum="-100" Maximum="100" ValueChanged="SliverValueChanged"/>
-				</DockPanel>
-				<DockPanel DockPanel.Dock="Top" LastChildFill="False">
-					<TextBlock Text="Saturation" DockPanel.Dock="Left"/>
-					<Slider Name="CG_Saturation_Slider" DockPanel.Dock="Right" HorizontalAlignment="Right" Width="200" Value="0" Minimum="-100" Maximum="100" ValueChanged="SliverValueChanged"/>
-				</DockPanel>
-				<DockPanel DockPanel.Dock="Top" LastChildFill="False">
-					<TextBlock Text="Contrast" DockPanel.Dock="Left"/>
-					<Slider Name="CG_Contrast_Slider" DockPanel.Dock="Right" HorizontalAlignment="Right" Width="200" Value="0" Minimum="-100" Maximum="100" ValueChanged="SliverValueChanged"/>
-				</DockPanel>
-			</DockPanel>
-		</GroupBox>
 
-		<GroupBox Header="Vignette" DockPanel.Dock="Top">
-			<DockPanel DockPanel.Dock="Top" LastChildFill="False">
-				<DockPanel DockPanel.Dock="Top" LastChildFill="False">
-					<CheckBox Name="Vignette_Enable_CheckBox" Content="Enable" DockPanel.Dock="Left" Checked="Checked" Unchecked="Checked"/>
-					<Button Content="Reset" DockPanel.Dock="Right" Height="Auto" />
-				</DockPanel>
-				<DockPanel DockPanel.Dock="Top" LastChildFill="False">
-					<TextBlock Text="Intensity" DockPanel.Dock="Left"/>
-					<Slider Name="Vignette_Intensity_Slider" DockPanel.Dock="Right" HorizontalAlignment="Right" Width="200" Value="0" Minimum="0" Maximum="1" ValueChanged="SliverValueChanged"/>
-				</DockPanel>
-				<DockPanel DockPanel.Dock="Top" LastChildFill="False">
-					<TextBlock Text="Smoothness" DockPanel.Dock="Left"/>
-					<Slider Name="Vignette_Smoothness_Slider" DockPanel.Dock="Right" HorizontalAlignment="Right" Width="200" Value="0" Minimum="0.01" Maximum="1" ValueChanged="SliverValueChanged"/>
-				</DockPanel>
-				<DockPanel DockPanel.Dock="Top" LastChildFill="False">
-					<TextBlock Text="Rounded" DockPanel.Dock="Left"/>
-					<Slider Name="Vignette_Rounded_Slider" DockPanel.Dock="Right" HorizontalAlignment="Right" Width="200" Value="0" Minimum="0" Maximum="1" ValueChanged="SliverValueChanged"/>
-				</DockPanel>
-			</DockPanel>
-		</GroupBox>
+				<GroupBox Header="Bloom" DockPanel.Dock="Top">
+					<DockPanel DockPanel.Dock="Top" LastChildFill="False">
+						<DockPanel DockPanel.Dock="Top" LastChildFill="False">
+							<CheckBox Name="Bloom_Enable_CheckBox" Content="Enable" DockPanel.Dock="Left" Checked="Checked" Unchecked="Checked"/>
+							<Button Content="Reset" DockPanel.Dock="Right" Height="Auto" />
+						</DockPanel>
+						<DockPanel DockPanel.Dock="Top" LastChildFill="False">
+							<TextBlock Text="Intensity" DockPanel.Dock="Left"/>
+							<Slider Name="Bloom_Intensity_Slider" DockPanel.Dock="Right" HorizontalAlignment="Right" Width="200" Value="0" Minimum="0" Maximum="10" TickFrequency="0.01" ValueChanged="SliverValueChanged"/>
+						</DockPanel>
+						<DockPanel DockPanel.Dock="Top" LastChildFill="False">
+							<TextBlock Text="Threshold" DockPanel.Dock="Left"/>
+							<Slider Name="Bloom_Threshold_Slider" DockPanel.Dock="Right" HorizontalAlignment="Right" Width="200" Value="0" Minimum="0" Maximum="1.5" TickFrequency="0.01" ValueChanged="SliverValueChanged"/>
+						</DockPanel>
+						<DockPanel DockPanel.Dock="Top" LastChildFill="False">
+							<Button Content="Color" Name="Bloom_Color_Button" DockPanel.Dock="Left" Height="Auto"  Click="Bloom_Color_Button_Clicked" />
+						</DockPanel>
+					</DockPanel>
+				</GroupBox>
 
-		<GroupBox Header="Chromatic Aberrattion" DockPanel.Dock="Top">
-			<DockPanel DockPanel.Dock="Top" LastChildFill="False">
-				<DockPanel DockPanel.Dock="Top" LastChildFill="False">
-					<CheckBox Name="CA_Enable_CheckBox" Content="Enable" DockPanel.Dock="Left" Checked="Checked" Unchecked="Checked"/>
-					<Button Content="Reset" DockPanel.Dock="Right" Height="Auto" />
-				</DockPanel>
-				<DockPanel DockPanel.Dock="Top" LastChildFill="False">
-					<TextBlock Text="Intensity" DockPanel.Dock="Left"/>
-					<Slider Name="CA_Intensity_Slider" DockPanel.Dock="Right" HorizontalAlignment="Right" Width="200" Value="0" Minimum="0" Maximum="1" ValueChanged="SliverValueChanged"/>
-				</DockPanel>
+				<GroupBox Header="Depth of Field" DockPanel.Dock="Top">
+					<DockPanel DockPanel.Dock="Top" LastChildFill="False">
+						<DockPanel DockPanel.Dock="Top" LastChildFill="False">
+							<CheckBox Name="DoF_Enable_CheckBox" Content="Enable" DockPanel.Dock="Left" Checked="Checked" Unchecked="Checked"/>
+							<Button Content="Reset" DockPanel.Dock="Right" Height="Auto" />
+						</DockPanel>
+						<DockPanel DockPanel.Dock="Top" LastChildFill="False">
+							<TextBlock Text="Focus Distance" DockPanel.Dock="Left"/>
+							<Slider Name="DoF_FocusDistance_Slider" DockPanel.Dock="Right" HorizontalAlignment="Right" Width="200" Value="0" Minimum="0" Maximum="5" TickFrequency="0.01" ValueChanged="SliverValueChanged"/>
+						</DockPanel>
+						<DockPanel DockPanel.Dock="Top" LastChildFill="False">
+							<TextBlock Text="Aperture" DockPanel.Dock="Left"/>
+							<Slider Name="DoF_Aperture_Slider" DockPanel.Dock="Right" HorizontalAlignment="Right" Width="200" Value="0" Minimum="0" Maximum="32" TickFrequency="0.01" ValueChanged="SliverValueChanged"/>
+						</DockPanel>
+						<DockPanel DockPanel.Dock="Top" LastChildFill="False">
+							<TextBlock Text="Focus Length" DockPanel.Dock="Left"/>
+							<Slider Name="DoF_FocusLength_Slider" DockPanel.Dock="Right" HorizontalAlignment="Right" Width="200" Value="0" Minimum="0" Maximum="300" TickFrequency="0.01" ValueChanged="SliverValueChanged"/>
+						</DockPanel>
+						<DockPanel DockPanel.Dock="Top" LastChildFill="False">
+							<TextBlock Text="Max Blur Size" DockPanel.Dock="Left"/>
+							<Slider Name="DoF_MaxBlurSize_Slider" DockPanel.Dock="Right" HorizontalAlignment="Right" Width="200" Value="0" Minimum="0" Maximum="3" TickFrequency="1" IsSnapToTickEnabled="True" ValueChanged="SliverValueChanged"/>
+						</DockPanel>
+					</DockPanel>
+				</GroupBox>
+
+				<GroupBox Header="Color Grading" DockPanel.Dock="Top">
+					<DockPanel DockPanel.Dock="Top" LastChildFill="False">
+						<DockPanel DockPanel.Dock="Top" LastChildFill="False">
+							<CheckBox Name="CG_Enable_CheckBox" Content="Enable" DockPanel.Dock="Left" Checked="Checked" Unchecked="Checked"/>
+							<Button Content="Reset" DockPanel.Dock="Right" Height="Auto" />
+						</DockPanel>
+						<DockPanel DockPanel.Dock="Top" LastChildFill="False">
+							<TextBlock Text="Temperature" DockPanel.Dock="Left"/>
+							<Slider Name="CG_Temperature_Slider" DockPanel.Dock="Right" HorizontalAlignment="Right" Width="200" Value="0" Minimum="-100" Maximum="100" ValueChanged="SliverValueChanged"/>
+						</DockPanel>
+						<DockPanel DockPanel.Dock="Top" LastChildFill="False">
+							<TextBlock Text="Saturation" DockPanel.Dock="Left"/>
+							<Slider Name="CG_Saturation_Slider" DockPanel.Dock="Right" HorizontalAlignment="Right" Width="200" Value="0" Minimum="-100" Maximum="100" ValueChanged="SliverValueChanged"/>
+						</DockPanel>
+						<DockPanel DockPanel.Dock="Top" LastChildFill="False">
+							<TextBlock Text="Contrast" DockPanel.Dock="Left"/>
+							<Slider Name="CG_Contrast_Slider" DockPanel.Dock="Right" HorizontalAlignment="Right" Width="200" Value="0" Minimum="-100" Maximum="100" ValueChanged="SliverValueChanged"/>
+						</DockPanel>
+						<DockPanel DockPanel.Dock="Top" LastChildFill="False">
+							<TextBlock Text="Gamma" DockPanel.Dock="Left"/>
+							<Slider Name="CG_Gamma_Slider" DockPanel.Dock="Right" HorizontalAlignment="Right" Width="200" Value="0" Minimum="-2" Maximum="5" ValueChanged="SliverValueChanged"/>
+						</DockPanel>
+						<DockPanel DockPanel.Dock="Top" LastChildFill="False">
+							<Button Content="Color Filter*" Name="CG_ColorFilter_Button" DockPanel.Dock="Left" Height="Auto" Click="CG_ColorFilter_Button_Clicked" />
+						</DockPanel>
+					</DockPanel>
+				</GroupBox>
+
+				<GroupBox Header="Vignette" DockPanel.Dock="Top">
+					<DockPanel DockPanel.Dock="Top" LastChildFill="False">
+						<DockPanel DockPanel.Dock="Top" LastChildFill="False">
+							<CheckBox Name="Vignette_Enable_CheckBox" Content="Enable" DockPanel.Dock="Left" Checked="Checked" Unchecked="Checked"/>
+							<Button Content="Reset" DockPanel.Dock="Right" Height="Auto" />
+						</DockPanel>
+						<DockPanel DockPanel.Dock="Top" LastChildFill="False">
+							<TextBlock Text="Intensity" DockPanel.Dock="Left"/>
+							<Slider Name="Vignette_Intensity_Slider" DockPanel.Dock="Right" HorizontalAlignment="Right" Width="200" Value="0" Minimum="0" Maximum="1" ValueChanged="SliverValueChanged"/>
+						</DockPanel>
+						<DockPanel DockPanel.Dock="Top" LastChildFill="False">
+							<TextBlock Text="Smoothness" DockPanel.Dock="Left"/>
+							<Slider Name="Vignette_Smoothness_Slider" DockPanel.Dock="Right" HorizontalAlignment="Right" Width="200" Value="0" Minimum="0.01" Maximum="1" ValueChanged="SliverValueChanged"/>
+						</DockPanel>
+						<DockPanel DockPanel.Dock="Top" LastChildFill="False">
+							<TextBlock Text="Roundness" DockPanel.Dock="Left"/>
+							<Slider Name="Vignette_Roundness_Slider" DockPanel.Dock="Right" HorizontalAlignment="Right" Width="200" Value="0" Minimum="0" Maximum="2" ValueChanged="SliverValueChanged"/>
+						</DockPanel>
+						<DockPanel DockPanel.Dock="Top" LastChildFill="False">
+							<Button Content="Color*" Name="Vignette_Color_Button"  DockPanel.Dock="Left" Height="Auto"  Click="Vignette_Color_Button_Clicked" Background="Black"  />
+						</DockPanel>
+					</DockPanel>
+				</GroupBox>
+
+				<GroupBox Header="Chromatic Aberrattion" DockPanel.Dock="Top">
+					<DockPanel DockPanel.Dock="Top" LastChildFill="False">
+						<DockPanel DockPanel.Dock="Top" LastChildFill="False">
+							<CheckBox Name="CA_Enable_CheckBox" Content="Enable" DockPanel.Dock="Left" Checked="Checked" Unchecked="Checked"/>
+							<Button Content="Reset" DockPanel.Dock="Right" Height="Auto" />
+						</DockPanel>
+						<DockPanel DockPanel.Dock="Top" LastChildFill="False">
+							<TextBlock Text="Intensity" DockPanel.Dock="Left"/>
+							<Slider Name="CA_Intensity_Slider" DockPanel.Dock="Right" HorizontalAlignment="Right" Width="200" Value="0" Minimum="0" Maximum="10" ValueChanged="SliverValueChanged"/>
+						</DockPanel>
+						<DockPanel DockPanel.Dock="Top" LastChildFill="False">
+							<CheckBox Name="CA_FastMode_CheckBox" Content="Fast Mode*" DockPanel.Dock="Left" Checked="Checked" Unchecked="Checked"/>
+						</DockPanel>
+					</DockPanel>
+				</GroupBox>
 			</DockPanel>
 		</GroupBox>
 

--- a/ControlWindowWPF/ControlWindowWPF/GraphicsOptionWindow.xaml
+++ b/ControlWindowWPF/ControlWindowWPF/GraphicsOptionWindow.xaml
@@ -11,7 +11,7 @@
 		<GroupBox Header="Anti-aliasing" DockPanel.Dock="Top">
 			<DockPanel DockPanel.Dock="Top" LastChildFill="False">
 				<DockPanel DockPanel.Dock="Top" LastChildFill="False">
-					<CheckBox Content="Enable" DockPanel.Dock="Left"/>
+					<CheckBox Name="AntiAliasing_Enable_CheckBox" Content="Enable" DockPanel.Dock="Left" Checked="Checked" Unchecked="Checked"/>
 				</DockPanel>
 			</DockPanel>
 		</GroupBox>
@@ -19,16 +19,16 @@
 		<GroupBox Header="Bloom" DockPanel.Dock="Top">
 			<DockPanel DockPanel.Dock="Top" LastChildFill="False">
 				<DockPanel DockPanel.Dock="Top" LastChildFill="False">
-					<CheckBox Content="Enable" DockPanel.Dock="Left"/>
+					<CheckBox Name="Bloom_Enable_CheckBox" Content="Enable" DockPanel.Dock="Left" Checked="Checked" Unchecked="Checked"/>
 					<Button Content="Reset" DockPanel.Dock="Right" Height="Auto" />
 				</DockPanel>
 				<DockPanel DockPanel.Dock="Top" LastChildFill="False">
 					<TextBlock Text="Intensity" DockPanel.Dock="Left"/>
-					<Slider DockPanel.Dock="Right" HorizontalAlignment="Right" Width="200" Value="0" Minimum="0" Maximum="1"/>
+					<Slider Name="Bloom_Intensity_Slider" DockPanel.Dock="Right" HorizontalAlignment="Right" Width="200" Value="0" Minimum="0" Maximum="1" ValueChanged="SliverValueChanged"/>
 				</DockPanel>
 				<DockPanel DockPanel.Dock="Top" LastChildFill="False">
 					<TextBlock Text="Threshold" DockPanel.Dock="Left"/>
-					<Slider DockPanel.Dock="Right" HorizontalAlignment="Right" Width="200" Value="0" Minimum="0" Maximum="1"/>
+					<Slider Name="Bloom_Threshold_Slider" DockPanel.Dock="Right" HorizontalAlignment="Right" Width="200" Value="0" Minimum="0" Maximum="1" ValueChanged="SliverValueChanged"/>
 				</DockPanel>
 			</DockPanel>
 		</GroupBox>
@@ -36,24 +36,24 @@
 		<GroupBox Header="Depth of Field" DockPanel.Dock="Top">
 			<DockPanel DockPanel.Dock="Top" LastChildFill="False">
 				<DockPanel DockPanel.Dock="Top" LastChildFill="False">
-					<CheckBox Content="Enable" DockPanel.Dock="Left"/>
+					<CheckBox Name="DoF_Enable_CheckBox" Content="Enable" DockPanel.Dock="Left" Checked="Checked" Unchecked="Checked"/>
 					<Button Content="Reset" DockPanel.Dock="Right" Height="Auto" />
 				</DockPanel>
 				<DockPanel DockPanel.Dock="Top" LastChildFill="False">
 					<TextBlock Text="Focus Distance" DockPanel.Dock="Left"/>
-					<Slider DockPanel.Dock="Right" HorizontalAlignment="Right" Width="200" Value="0" Minimum="0" Maximum="1"/>
+					<Slider Name="DoF_FocusDistance_Slider" DockPanel.Dock="Right" HorizontalAlignment="Right" Width="200" Value="0" Minimum="0" Maximum="1" ValueChanged="SliverValueChanged"/>
 				</DockPanel>
 				<DockPanel DockPanel.Dock="Top" LastChildFill="False">
 					<TextBlock Text="Aperture" DockPanel.Dock="Left"/>
-					<Slider DockPanel.Dock="Right" HorizontalAlignment="Right" Width="200" Value="0" Minimum="0" Maximum="1"/>
+					<Slider Name="DoF_Aperture_Slider" DockPanel.Dock="Right" HorizontalAlignment="Right" Width="200" Value="0" Minimum="0" Maximum="1" ValueChanged="SliverValueChanged"/>
 				</DockPanel>
 				<DockPanel DockPanel.Dock="Top" LastChildFill="False">
 					<TextBlock Text="Focus Length" DockPanel.Dock="Left"/>
-					<Slider DockPanel.Dock="Right" HorizontalAlignment="Right" Width="200" Value="0" Minimum="0" Maximum="1"/>
+					<Slider Name="DoF_FocusLength_Slider" DockPanel.Dock="Right" HorizontalAlignment="Right" Width="200" Value="0" Minimum="0" Maximum="1" ValueChanged="SliverValueChanged"/>
 				</DockPanel>
 				<DockPanel DockPanel.Dock="Top" LastChildFill="False">
 					<TextBlock Text="Max Blur Size" DockPanel.Dock="Left"/>
-					<Slider DockPanel.Dock="Right" HorizontalAlignment="Right" Width="200" Value="0" Minimum="0" Maximum="1"/>
+					<Slider Name="DoF_MaxBlurSize_Slider" DockPanel.Dock="Right" HorizontalAlignment="Right" Width="200" Value="0" Minimum="0" Maximum="1" ValueChanged="SliverValueChanged"/>
 				</DockPanel>
 			</DockPanel>
 		</GroupBox>
@@ -61,20 +61,20 @@
 		<GroupBox Header="Color Grading" DockPanel.Dock="Top">
 			<DockPanel DockPanel.Dock="Top" LastChildFill="False">
 				<DockPanel DockPanel.Dock="Top" LastChildFill="False">
-					<CheckBox Content="Enable" DockPanel.Dock="Left"/>
+					<CheckBox Name="CG_Enable_CheckBox" Content="Enable" DockPanel.Dock="Left" Checked="Checked" Unchecked="Checked"/>
 					<Button Content="Reset" DockPanel.Dock="Right" Height="Auto" />
 				</DockPanel>
 				<DockPanel DockPanel.Dock="Top" LastChildFill="False">
 					<TextBlock Text="Temperature" DockPanel.Dock="Left"/>
-					<Slider DockPanel.Dock="Right" HorizontalAlignment="Right" Width="200" Value="0" Minimum="0" Maximum="1"/>
+					<Slider Name="CG_Temperature_Slider" DockPanel.Dock="Right" HorizontalAlignment="Right" Width="200" Value="0" Minimum="0" Maximum="1" ValueChanged="SliverValueChanged"/>
 				</DockPanel>
 				<DockPanel DockPanel.Dock="Top" LastChildFill="False">
 					<TextBlock Text="Saturation" DockPanel.Dock="Left"/>
-					<Slider DockPanel.Dock="Right" HorizontalAlignment="Right" Width="200" Value="0" Minimum="0" Maximum="1"/>
+					<Slider Name="CG_Saturation_Slider" DockPanel.Dock="Right" HorizontalAlignment="Right" Width="200" Value="0" Minimum="0" Maximum="1" ValueChanged="SliverValueChanged"/>
 				</DockPanel>
 				<DockPanel DockPanel.Dock="Top" LastChildFill="False">
 					<TextBlock Text="Contrast" DockPanel.Dock="Left"/>
-					<Slider DockPanel.Dock="Right" HorizontalAlignment="Right" Width="200" Value="0" Minimum="0" Maximum="1"/>
+					<Slider Name="CG_Contrast_Slider" DockPanel.Dock="Right" HorizontalAlignment="Right" Width="200" Value="0" Minimum="0" Maximum="1" ValueChanged="SliverValueChanged"/>
 				</DockPanel>
 			</DockPanel>
 		</GroupBox>
@@ -82,20 +82,20 @@
 		<GroupBox Header="Vignette" DockPanel.Dock="Top">
 			<DockPanel DockPanel.Dock="Top" LastChildFill="False">
 				<DockPanel DockPanel.Dock="Top" LastChildFill="False">
-					<CheckBox Content="Enable" DockPanel.Dock="Left"/>
+					<CheckBox Name="Vignette_Enable_CheckBox" Content="Enable" DockPanel.Dock="Left" Checked="Checked" Unchecked="Checked"/>
 					<Button Content="Reset" DockPanel.Dock="Right" Height="Auto" />
 				</DockPanel>
 				<DockPanel DockPanel.Dock="Top" LastChildFill="False">
 					<TextBlock Text="Intensity" DockPanel.Dock="Left"/>
-					<Slider DockPanel.Dock="Right" HorizontalAlignment="Right" Width="200" Value="0" Minimum="0" Maximum="1"/>
+					<Slider Name="Vignette_Intensity_Slider" DockPanel.Dock="Right" HorizontalAlignment="Right" Width="200" Value="0" Minimum="0" Maximum="1" ValueChanged="SliverValueChanged"/>
 				</DockPanel>
 				<DockPanel DockPanel.Dock="Top" LastChildFill="False">
 					<TextBlock Text="Smoothness" DockPanel.Dock="Left"/>
-					<Slider DockPanel.Dock="Right" HorizontalAlignment="Right" Width="200" Value="0" Minimum="0" Maximum="1"/>
+					<Slider Name="Vignette_Smoothness_Slider" DockPanel.Dock="Right" HorizontalAlignment="Right" Width="200" Value="0" Minimum="0" Maximum="1" ValueChanged="SliverValueChanged"/>
 				</DockPanel>
 				<DockPanel DockPanel.Dock="Top" LastChildFill="False">
 					<TextBlock Text="Rounded" DockPanel.Dock="Left"/>
-					<Slider DockPanel.Dock="Right" HorizontalAlignment="Right" Width="200" Value="0" Minimum="0" Maximum="1"/>
+					<Slider Name="Vignette_Rounded_Slider" DockPanel.Dock="Right" HorizontalAlignment="Right" Width="200" Value="0" Minimum="0" Maximum="1" ValueChanged="SliverValueChanged"/>
 				</DockPanel>
 			</DockPanel>
 		</GroupBox>
@@ -103,12 +103,12 @@
 		<GroupBox Header="Chromatic Aberrattion" DockPanel.Dock="Top">
 			<DockPanel DockPanel.Dock="Top" LastChildFill="False">
 				<DockPanel DockPanel.Dock="Top" LastChildFill="False">
+					<CheckBox Name="CA_Enable_CheckBox" Content="Enable" DockPanel.Dock="Left" Checked="Checked" Unchecked="Checked"/>
 					<Button Content="Reset" DockPanel.Dock="Right" Height="Auto" />
-					<CheckBox Content="Enable" DockPanel.Dock="Left"/>
 				</DockPanel>
 				<DockPanel DockPanel.Dock="Top" LastChildFill="False">
 					<TextBlock Text="Intensity" DockPanel.Dock="Left"/>
-					<Slider DockPanel.Dock="Right" HorizontalAlignment="Right" Width="200" Value="0" Minimum="0" Maximum="1"/>
+					<Slider Name="CA_Intensity_Slider" DockPanel.Dock="Right" HorizontalAlignment="Right" Width="200" Value="0" Minimum="0" Maximum="1" ValueChanged="SliverValueChanged"/>
 				</DockPanel>
 			</DockPanel>
 		</GroupBox>

--- a/ControlWindowWPF/ControlWindowWPF/GraphicsOptionWindow.xaml
+++ b/ControlWindowWPF/ControlWindowWPF/GraphicsOptionWindow.xaml
@@ -1,0 +1,117 @@
+﻿<Window x:Class="VirtualMotionCaptureControlPanel.GraphicsOptionWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:local="clr-namespace:VirtualMotionCaptureControlPanel"
+        mc:Ignorable="d"
+        Title="Graphics Option" Width="400" SizeToContent="Height" Loaded="Window_Loaded" Closing="Window_Closing">
+	<DockPanel LastChildFill="False" Margin="5">
+		
+		<GroupBox Header="Anti-aliasing" DockPanel.Dock="Top">
+			<DockPanel DockPanel.Dock="Top" LastChildFill="False">
+				<DockPanel DockPanel.Dock="Top" LastChildFill="False">
+					<CheckBox Content="Enable" DockPanel.Dock="Left"/>
+				</DockPanel>
+			</DockPanel>
+		</GroupBox>
+		
+		<GroupBox Header="Bloom" DockPanel.Dock="Top">
+			<DockPanel DockPanel.Dock="Top" LastChildFill="False">
+				<DockPanel DockPanel.Dock="Top" LastChildFill="False">
+					<CheckBox Content="Enable" DockPanel.Dock="Left"/>
+					<Button Content="Reset" DockPanel.Dock="Right" Height="Auto" />
+				</DockPanel>
+				<DockPanel DockPanel.Dock="Top" LastChildFill="False">
+					<TextBlock Text="Intensity" DockPanel.Dock="Left"/>
+					<Slider DockPanel.Dock="Right" HorizontalAlignment="Right" Width="200" Value="0" Minimum="0" Maximum="1"/>
+				</DockPanel>
+				<DockPanel DockPanel.Dock="Top" LastChildFill="False">
+					<TextBlock Text="Threshold" DockPanel.Dock="Left"/>
+					<Slider DockPanel.Dock="Right" HorizontalAlignment="Right" Width="200" Value="0" Minimum="0" Maximum="1"/>
+				</DockPanel>
+			</DockPanel>
+		</GroupBox>
+		
+		<GroupBox Header="Depth of Field" DockPanel.Dock="Top">
+			<DockPanel DockPanel.Dock="Top" LastChildFill="False">
+				<DockPanel DockPanel.Dock="Top" LastChildFill="False">
+					<CheckBox Content="Enable" DockPanel.Dock="Left"/>
+					<Button Content="Reset" DockPanel.Dock="Right" Height="Auto" />
+				</DockPanel>
+				<DockPanel DockPanel.Dock="Top" LastChildFill="False">
+					<TextBlock Text="Focus Distance" DockPanel.Dock="Left"/>
+					<Slider DockPanel.Dock="Right" HorizontalAlignment="Right" Width="200" Value="0" Minimum="0" Maximum="1"/>
+				</DockPanel>
+				<DockPanel DockPanel.Dock="Top" LastChildFill="False">
+					<TextBlock Text="Aperture" DockPanel.Dock="Left"/>
+					<Slider DockPanel.Dock="Right" HorizontalAlignment="Right" Width="200" Value="0" Minimum="0" Maximum="1"/>
+				</DockPanel>
+				<DockPanel DockPanel.Dock="Top" LastChildFill="False">
+					<TextBlock Text="Focus Length" DockPanel.Dock="Left"/>
+					<Slider DockPanel.Dock="Right" HorizontalAlignment="Right" Width="200" Value="0" Minimum="0" Maximum="1"/>
+				</DockPanel>
+				<DockPanel DockPanel.Dock="Top" LastChildFill="False">
+					<TextBlock Text="Max Blur Size" DockPanel.Dock="Left"/>
+					<Slider DockPanel.Dock="Right" HorizontalAlignment="Right" Width="200" Value="0" Minimum="0" Maximum="1"/>
+				</DockPanel>
+			</DockPanel>
+		</GroupBox>
+
+		<GroupBox Header="Color Grading" DockPanel.Dock="Top">
+			<DockPanel DockPanel.Dock="Top" LastChildFill="False">
+				<DockPanel DockPanel.Dock="Top" LastChildFill="False">
+					<CheckBox Content="Enable" DockPanel.Dock="Left"/>
+					<Button Content="Reset" DockPanel.Dock="Right" Height="Auto" />
+				</DockPanel>
+				<DockPanel DockPanel.Dock="Top" LastChildFill="False">
+					<TextBlock Text="Temperature" DockPanel.Dock="Left"/>
+					<Slider DockPanel.Dock="Right" HorizontalAlignment="Right" Width="200" Value="0" Minimum="0" Maximum="1"/>
+				</DockPanel>
+				<DockPanel DockPanel.Dock="Top" LastChildFill="False">
+					<TextBlock Text="Saturation" DockPanel.Dock="Left"/>
+					<Slider DockPanel.Dock="Right" HorizontalAlignment="Right" Width="200" Value="0" Minimum="0" Maximum="1"/>
+				</DockPanel>
+				<DockPanel DockPanel.Dock="Top" LastChildFill="False">
+					<TextBlock Text="Contrast" DockPanel.Dock="Left"/>
+					<Slider DockPanel.Dock="Right" HorizontalAlignment="Right" Width="200" Value="0" Minimum="0" Maximum="1"/>
+				</DockPanel>
+			</DockPanel>
+		</GroupBox>
+
+		<GroupBox Header="Vignette" DockPanel.Dock="Top">
+			<DockPanel DockPanel.Dock="Top" LastChildFill="False">
+				<DockPanel DockPanel.Dock="Top" LastChildFill="False">
+					<CheckBox Content="Enable" DockPanel.Dock="Left"/>
+					<Button Content="Reset" DockPanel.Dock="Right" Height="Auto" />
+				</DockPanel>
+				<DockPanel DockPanel.Dock="Top" LastChildFill="False">
+					<TextBlock Text="Intensity" DockPanel.Dock="Left"/>
+					<Slider DockPanel.Dock="Right" HorizontalAlignment="Right" Width="200" Value="0" Minimum="0" Maximum="1"/>
+				</DockPanel>
+				<DockPanel DockPanel.Dock="Top" LastChildFill="False">
+					<TextBlock Text="Smoothness" DockPanel.Dock="Left"/>
+					<Slider DockPanel.Dock="Right" HorizontalAlignment="Right" Width="200" Value="0" Minimum="0" Maximum="1"/>
+				</DockPanel>
+				<DockPanel DockPanel.Dock="Top" LastChildFill="False">
+					<TextBlock Text="Rounded" DockPanel.Dock="Left"/>
+					<Slider DockPanel.Dock="Right" HorizontalAlignment="Right" Width="200" Value="0" Minimum="0" Maximum="1"/>
+				</DockPanel>
+			</DockPanel>
+		</GroupBox>
+
+		<GroupBox Header="Chromatic Aberrattion" DockPanel.Dock="Top">
+			<DockPanel DockPanel.Dock="Top" LastChildFill="False">
+				<DockPanel DockPanel.Dock="Top" LastChildFill="False">
+					<Button Content="Reset" DockPanel.Dock="Right" Height="Auto" />
+					<CheckBox Content="Enable" DockPanel.Dock="Left"/>
+				</DockPanel>
+				<DockPanel DockPanel.Dock="Top" LastChildFill="False">
+					<TextBlock Text="Intensity" DockPanel.Dock="Left"/>
+					<Slider DockPanel.Dock="Right" HorizontalAlignment="Right" Width="200" Value="0" Minimum="0" Maximum="1"/>
+				</DockPanel>
+			</DockPanel>
+		</GroupBox>
+
+	</DockPanel>
+</Window>

--- a/ControlWindowWPF/ControlWindowWPF/GraphicsOptionWindow.xaml
+++ b/ControlWindowWPF/ControlWindowWPF/GraphicsOptionWindow.xaml
@@ -18,7 +18,7 @@
 					<DockPanel DockPanel.Dock="Top" LastChildFill="False">
 						<DockPanel DockPanel.Dock="Top" LastChildFill="False">
 							<CheckBox Name="Bloom_Enable_CheckBox" Content="Enable" DockPanel.Dock="Left" Checked="Checked" Unchecked="Checked"/>
-							<Button Content="Reset" DockPanel.Dock="Right" Height="Auto" />
+							<Button Content="Reset" Click="Bloom_Reset_Clicked" DockPanel.Dock="Right" Height="Auto" />
 						</DockPanel>
 						<DockPanel DockPanel.Dock="Top" LastChildFill="False">
 							<TextBlock Text="Intensity" DockPanel.Dock="Left"/>
@@ -38,7 +38,7 @@
 					<DockPanel DockPanel.Dock="Top" LastChildFill="False">
 						<DockPanel DockPanel.Dock="Top" LastChildFill="False">
 							<CheckBox Name="DoF_Enable_CheckBox" Content="Enable" DockPanel.Dock="Left" Checked="Checked" Unchecked="Checked"/>
-							<Button Content="Reset" DockPanel.Dock="Right" Height="Auto" />
+							<Button Content="Reset" Click="DoF_Reset_Clicked"  DockPanel.Dock="Right" Height="Auto" />
 						</DockPanel>
 						<DockPanel DockPanel.Dock="Top" LastChildFill="False">
 							<TextBlock Text="Focus Distance" DockPanel.Dock="Left"/>
@@ -63,7 +63,7 @@
 					<DockPanel DockPanel.Dock="Top" LastChildFill="False">
 						<DockPanel DockPanel.Dock="Top" LastChildFill="False">
 							<CheckBox Name="CG_Enable_CheckBox" Content="Enable" DockPanel.Dock="Left" Checked="Checked" Unchecked="Checked"/>
-							<Button Content="Reset" DockPanel.Dock="Right" Height="Auto" />
+							<Button Content="Reset" Click="CG_Reset_Clicked"  DockPanel.Dock="Right" Height="Auto" />
 						</DockPanel>
 						<DockPanel DockPanel.Dock="Top" LastChildFill="False">
 							<TextBlock Text="Temperature" DockPanel.Dock="Left"/>
@@ -82,7 +82,7 @@
 							<Slider Name="CG_Gamma_Slider" DockPanel.Dock="Right" HorizontalAlignment="Right" Width="200" Value="0" Minimum="-2" Maximum="5" ValueChanged="SliverValueChanged"/>
 						</DockPanel>
 						<DockPanel DockPanel.Dock="Top" LastChildFill="False">
-							<Button Content="Color Filter*" Name="CG_ColorFilter_Button" DockPanel.Dock="Left" Height="Auto" Click="CG_ColorFilter_Button_Clicked" />
+							<Button Content="Color Filter" Name="CG_ColorFilter_Button" DockPanel.Dock="Left" Height="Auto" Click="CG_ColorFilter_Button_Clicked" />
 						</DockPanel>
 					</DockPanel>
 				</GroupBox>
@@ -91,7 +91,7 @@
 					<DockPanel DockPanel.Dock="Top" LastChildFill="False">
 						<DockPanel DockPanel.Dock="Top" LastChildFill="False">
 							<CheckBox Name="Vignette_Enable_CheckBox" Content="Enable" DockPanel.Dock="Left" Checked="Checked" Unchecked="Checked"/>
-							<Button Content="Reset" DockPanel.Dock="Right" Height="Auto" />
+							<Button Content="Reset" Click="Vignette_Reset_Clicked"  DockPanel.Dock="Right" Height="Auto" />
 						</DockPanel>
 						<DockPanel DockPanel.Dock="Top" LastChildFill="False">
 							<TextBlock Text="Intensity" DockPanel.Dock="Left"/>
@@ -103,10 +103,10 @@
 						</DockPanel>
 						<DockPanel DockPanel.Dock="Top" LastChildFill="False">
 							<TextBlock Text="Roundness" DockPanel.Dock="Left"/>
-							<Slider Name="Vignette_Roundness_Slider" DockPanel.Dock="Right" HorizontalAlignment="Right" Width="200" Value="0" Minimum="0" Maximum="2" ValueChanged="SliverValueChanged"/>
+							<Slider Name="Vignette_Roundness_Slider" DockPanel.Dock="Right" HorizontalAlignment="Right" Width="200" Value="0" Minimum="0" Maximum="1" ValueChanged="SliverValueChanged"/>
 						</DockPanel>
 						<DockPanel DockPanel.Dock="Top" LastChildFill="False">
-							<Button Content="Color*" Name="Vignette_Color_Button"  DockPanel.Dock="Left" Height="Auto"  Click="Vignette_Color_Button_Clicked" Background="Black"  />
+							<Button Content="Color" Name="Vignette_Color_Button"  DockPanel.Dock="Left" Height="Auto"  Click="Vignette_Color_Button_Clicked" Background="Black"  />
 						</DockPanel>
 					</DockPanel>
 				</GroupBox>
@@ -115,14 +115,14 @@
 					<DockPanel DockPanel.Dock="Top" LastChildFill="False">
 						<DockPanel DockPanel.Dock="Top" LastChildFill="False">
 							<CheckBox Name="CA_Enable_CheckBox" Content="Enable" DockPanel.Dock="Left" Checked="Checked" Unchecked="Checked"/>
-							<Button Content="Reset" DockPanel.Dock="Right" Height="Auto" />
+							<Button Content="Reset" Click="CA_Reset_Clicked"  DockPanel.Dock="Right" Height="Auto" />
 						</DockPanel>
 						<DockPanel DockPanel.Dock="Top" LastChildFill="False">
 							<TextBlock Text="Intensity" DockPanel.Dock="Left"/>
-							<Slider Name="CA_Intensity_Slider" DockPanel.Dock="Right" HorizontalAlignment="Right" Width="200" Value="0" Minimum="0" Maximum="10" ValueChanged="SliverValueChanged"/>
+							<Slider Name="CA_Intensity_Slider" DockPanel.Dock="Right" HorizontalAlignment="Right" Width="200" Value="0" Minimum="0" Maximum="1" ValueChanged="SliverValueChanged"/>
 						</DockPanel>
 						<DockPanel DockPanel.Dock="Top" LastChildFill="False">
-							<CheckBox Name="CA_FastMode_CheckBox" Content="Fast Mode*" DockPanel.Dock="Left" Checked="Checked" Unchecked="Checked"/>
+							<CheckBox Name="CA_FastMode_CheckBox" Content="Fast Mode" DockPanel.Dock="Left" Checked="Checked" Unchecked="Checked"/>
 						</DockPanel>
 					</DockPanel>
 				</GroupBox>

--- a/ControlWindowWPF/ControlWindowWPF/GraphicsOptionWindow.xaml
+++ b/ControlWindowWPF/ControlWindowWPF/GraphicsOptionWindow.xaml
@@ -24,11 +24,11 @@
 				</DockPanel>
 				<DockPanel DockPanel.Dock="Top" LastChildFill="False">
 					<TextBlock Text="Intensity" DockPanel.Dock="Left"/>
-					<Slider Name="Bloom_Intensity_Slider" DockPanel.Dock="Right" HorizontalAlignment="Right" Width="200" Value="0" Minimum="0" Maximum="1" ValueChanged="SliverValueChanged"/>
+					<Slider Name="Bloom_Intensity_Slider" DockPanel.Dock="Right" HorizontalAlignment="Right" Width="200" Value="0" Minimum="0" Maximum="10" TickFrequency="0.01" ValueChanged="SliverValueChanged"/>
 				</DockPanel>
 				<DockPanel DockPanel.Dock="Top" LastChildFill="False">
 					<TextBlock Text="Threshold" DockPanel.Dock="Left"/>
-					<Slider Name="Bloom_Threshold_Slider" DockPanel.Dock="Right" HorizontalAlignment="Right" Width="200" Value="0" Minimum="0" Maximum="1" ValueChanged="SliverValueChanged"/>
+					<Slider Name="Bloom_Threshold_Slider" DockPanel.Dock="Right" HorizontalAlignment="Right" Width="200" Value="0" Minimum="0" Maximum="1.5" TickFrequency="0.01" ValueChanged="SliverValueChanged"/>
 				</DockPanel>
 			</DockPanel>
 		</GroupBox>
@@ -41,19 +41,19 @@
 				</DockPanel>
 				<DockPanel DockPanel.Dock="Top" LastChildFill="False">
 					<TextBlock Text="Focus Distance" DockPanel.Dock="Left"/>
-					<Slider Name="DoF_FocusDistance_Slider" DockPanel.Dock="Right" HorizontalAlignment="Right" Width="200" Value="0" Minimum="0" Maximum="1" ValueChanged="SliverValueChanged"/>
+					<Slider Name="DoF_FocusDistance_Slider" DockPanel.Dock="Right" HorizontalAlignment="Right" Width="200" Value="0" Minimum="0" Maximum="100" TickFrequency="0.01" ValueChanged="SliverValueChanged"/>
 				</DockPanel>
 				<DockPanel DockPanel.Dock="Top" LastChildFill="False">
 					<TextBlock Text="Aperture" DockPanel.Dock="Left"/>
-					<Slider Name="DoF_Aperture_Slider" DockPanel.Dock="Right" HorizontalAlignment="Right" Width="200" Value="0" Minimum="0" Maximum="1" ValueChanged="SliverValueChanged"/>
+					<Slider Name="DoF_Aperture_Slider" DockPanel.Dock="Right" HorizontalAlignment="Right" Width="200" Value="0" Minimum="0" Maximum="32" TickFrequency="0.01" ValueChanged="SliverValueChanged"/>
 				</DockPanel>
 				<DockPanel DockPanel.Dock="Top" LastChildFill="False">
 					<TextBlock Text="Focus Length" DockPanel.Dock="Left"/>
-					<Slider Name="DoF_FocusLength_Slider" DockPanel.Dock="Right" HorizontalAlignment="Right" Width="200" Value="0" Minimum="0" Maximum="1" ValueChanged="SliverValueChanged"/>
+					<Slider Name="DoF_FocusLength_Slider" DockPanel.Dock="Right" HorizontalAlignment="Right" Width="200" Value="0" Minimum="0" Maximum="300" TickFrequency="0.01" ValueChanged="SliverValueChanged"/>
 				</DockPanel>
 				<DockPanel DockPanel.Dock="Top" LastChildFill="False">
 					<TextBlock Text="Max Blur Size" DockPanel.Dock="Left"/>
-					<Slider Name="DoF_MaxBlurSize_Slider" DockPanel.Dock="Right" HorizontalAlignment="Right" Width="200" Value="0" Minimum="0" Maximum="1" ValueChanged="SliverValueChanged"/>
+					<Slider Name="DoF_MaxBlurSize_Slider" DockPanel.Dock="Right" HorizontalAlignment="Right" Width="200" Value="0" Minimum="0" Maximum="3" TickFrequency="1" IsSnapToTickEnabled="True" ValueChanged="SliverValueChanged"/>
 				</DockPanel>
 			</DockPanel>
 		</GroupBox>
@@ -66,15 +66,15 @@
 				</DockPanel>
 				<DockPanel DockPanel.Dock="Top" LastChildFill="False">
 					<TextBlock Text="Temperature" DockPanel.Dock="Left"/>
-					<Slider Name="CG_Temperature_Slider" DockPanel.Dock="Right" HorizontalAlignment="Right" Width="200" Value="0" Minimum="0" Maximum="1" ValueChanged="SliverValueChanged"/>
+					<Slider Name="CG_Temperature_Slider" DockPanel.Dock="Right" HorizontalAlignment="Right" Width="200" Value="0" Minimum="-100" Maximum="100" ValueChanged="SliverValueChanged"/>
 				</DockPanel>
 				<DockPanel DockPanel.Dock="Top" LastChildFill="False">
 					<TextBlock Text="Saturation" DockPanel.Dock="Left"/>
-					<Slider Name="CG_Saturation_Slider" DockPanel.Dock="Right" HorizontalAlignment="Right" Width="200" Value="0" Minimum="0" Maximum="1" ValueChanged="SliverValueChanged"/>
+					<Slider Name="CG_Saturation_Slider" DockPanel.Dock="Right" HorizontalAlignment="Right" Width="200" Value="0" Minimum="-100" Maximum="100" ValueChanged="SliverValueChanged"/>
 				</DockPanel>
 				<DockPanel DockPanel.Dock="Top" LastChildFill="False">
 					<TextBlock Text="Contrast" DockPanel.Dock="Left"/>
-					<Slider Name="CG_Contrast_Slider" DockPanel.Dock="Right" HorizontalAlignment="Right" Width="200" Value="0" Minimum="0" Maximum="1" ValueChanged="SliverValueChanged"/>
+					<Slider Name="CG_Contrast_Slider" DockPanel.Dock="Right" HorizontalAlignment="Right" Width="200" Value="0" Minimum="-100" Maximum="100" ValueChanged="SliverValueChanged"/>
 				</DockPanel>
 			</DockPanel>
 		</GroupBox>
@@ -91,7 +91,7 @@
 				</DockPanel>
 				<DockPanel DockPanel.Dock="Top" LastChildFill="False">
 					<TextBlock Text="Smoothness" DockPanel.Dock="Left"/>
-					<Slider Name="Vignette_Smoothness_Slider" DockPanel.Dock="Right" HorizontalAlignment="Right" Width="200" Value="0" Minimum="0" Maximum="1" ValueChanged="SliverValueChanged"/>
+					<Slider Name="Vignette_Smoothness_Slider" DockPanel.Dock="Right" HorizontalAlignment="Right" Width="200" Value="0" Minimum="0.01" Maximum="1" ValueChanged="SliverValueChanged"/>
 				</DockPanel>
 				<DockPanel DockPanel.Dock="Top" LastChildFill="False">
 					<TextBlock Text="Rounded" DockPanel.Dock="Left"/>

--- a/ControlWindowWPF/ControlWindowWPF/GraphicsOptionWindow.xaml.cs
+++ b/ControlWindowWPF/ControlWindowWPF/GraphicsOptionWindow.xaml.cs
@@ -52,28 +52,28 @@ namespace VirtualMotionCaptureControlPanel
             await Globals.Client.SendCommandAsync(new PipeCommands.SetPostProcessing { 
                 AntiAliasing_Enable = AntiAliasing_Enable_CheckBox.IsChecked.Value,
                 
-                Bloom_Enable = Bloom_Enable_CheckBox.IsChecked ?? false,
-                Bloom_Intensity = (float)Bloom_Intensity_Slider.Value,
-                Bloom_Threshold = (float)Bloom_Threshold_Slider.Value,
+                Bloom_Enable = Bloom_Enable_CheckBox?.IsChecked ?? false,
+                Bloom_Intensity = (float)Bloom_Intensity_Slider?.Value,
+                Bloom_Threshold = (float)Bloom_Threshold_Slider?.Value,
 
-                DoF_Enable = DoF_Enable_CheckBox.IsChecked ?? false,
-                DoF_FocusDistance = (float)DoF_FocusDistance_Slider.Value,
-                DoF_Aperture = (float)DoF_Aperture_Slider.Value,
-                DoF_FocusLength = (float)DoF_FocusLength_Slider.Value,
-                DoF_MaxBlurSize = (float)DoF_MaxBlurSize_Slider.Value,
+                DoF_Enable = DoF_Enable_CheckBox?.IsChecked ?? false,
+                DoF_FocusDistance = (float)(DoF_FocusDistance_Slider?.Value ?? 0f),
+                DoF_Aperture = (float)(DoF_Aperture_Slider?.Value ?? 0f),
+                DoF_FocusLength = (float)(DoF_FocusLength_Slider?.Value ?? 0f),
+                DoF_MaxBlurSize = (float)(DoF_MaxBlurSize_Slider?.Value ?? 0f),
 
-                CG_Enable = CG_Enable_CheckBox.IsChecked ?? false,
-                CG_Temperature = (float)CG_Temperature_Slider.Value,
-                CG_Saturation = (float)CG_Saturation_Slider.Value,
-                CG_Contrast = (float)CG_Contrast_Slider.Value,
+                CG_Enable = CG_Enable_CheckBox?.IsChecked ?? false,
+                CG_Temperature = (float)(CG_Temperature_Slider?.Value ?? 0f),
+                CG_Saturation = (float)(CG_Saturation_Slider?.Value ?? 0f),
+                CG_Contrast = (float)(CG_Contrast_Slider?.Value ?? 0f),
 
-                Vignette_Enable = Vignette_Enable_CheckBox.IsChecked ?? false,
-                Vignette_Intensity = (float)Vignette_Intensity_Slider.Value,
-                Vignette_Smoothness = (float)Vignette_Smoothness_Slider.Value,
-                Vignette_Rounded = (float)Vignette_Rounded_Slider.Value,
+                Vignette_Enable = Vignette_Enable_CheckBox?.IsChecked ?? false,
+                Vignette_Intensity = (float)(Vignette_Intensity_Slider?.Value ?? 0f),
+                Vignette_Smoothness = (float)(Vignette_Smoothness_Slider?.Value ?? 0f),
+                Vignette_Rounded = (float)(Vignette_Rounded_Slider?.Value ?? 0f),
 
-                CA_Enable = CA_Enable_CheckBox.IsChecked ?? false,
-                CA_Intensity = (float)CA_Intensity_Slider.Value
+                CA_Enable = CA_Enable_CheckBox?.IsChecked ?? false,
+                CA_Intensity = (float)(CA_Intensity_Slider?.Value ?? 0f)
             });
         }
         private async void ValueApply(PipeCommands.SetPostProcessing d)

--- a/ControlWindowWPF/ControlWindowWPF/GraphicsOptionWindow.xaml.cs
+++ b/ControlWindowWPF/ControlWindowWPF/GraphicsOptionWindow.xaml.cs
@@ -30,7 +30,7 @@ namespace VirtualMotionCaptureControlPanel
         {
             Globals.Client.ReceivedEvent += Client_Received;
 
-            await Globals.Client.SendCommandAsync(new PipeCommands.GetPostProcessing { });
+            await Globals.Client.SendCommandAsync(new PipeCommands.GetAdvancedGraphicsOption { });
             Initializing = false;
         }
 
@@ -41,9 +41,9 @@ namespace VirtualMotionCaptureControlPanel
 
         private async void Client_Received(object sender, DataReceivedEventArgs e)
         {
-            if (e.CommandType == typeof(PipeCommands.SetPostProcessing))
+            if (e.CommandType == typeof(PipeCommands.SetAdvancedGraphicsOption))
             {
-                var d = (PipeCommands.SetPostProcessing)e.Data;
+                var d = (PipeCommands.SetAdvancedGraphicsOption)e.Data;
                 ValueApply(d);
             }
         }
@@ -52,12 +52,17 @@ namespace VirtualMotionCaptureControlPanel
         {
             if (Initializing) { return; }
             //セットされたpostProcessingValueを送信する
-            await Globals.Client.SendCommandAsync(new PipeCommands.SetPostProcessing { 
-                PPS_Enable = true, //暫定
+            await Globals.Client.SendCommandAsync(new PipeCommands.SetAdvancedGraphicsOption
+            { 
+                PPS_Enable = Global_Enable_CheckBox?.IsChecked ?? false,
                 
                 Bloom_Enable = Bloom_Enable_CheckBox?.IsChecked ?? false,
                 Bloom_Intensity = (float)Bloom_Intensity_Slider?.Value,
                 Bloom_Threshold = (float)Bloom_Threshold_Slider?.Value,
+                Bloom_Color_r = (float)((Bloom_Color_Button.Background as SolidColorBrush).Color.R / 255.0),
+                Bloom_Color_g = (float)((Bloom_Color_Button.Background as SolidColorBrush).Color.G / 255.0),
+                Bloom_Color_b = (float)((Bloom_Color_Button.Background as SolidColorBrush).Color.B / 255.0),
+                Bloom_Color_a = (float)((Bloom_Color_Button.Background as SolidColorBrush).Color.A / 255.0),
 
                 DoF_Enable = DoF_Enable_CheckBox?.IsChecked ?? false,
                 DoF_FocusDistance = (float)(DoF_FocusDistance_Slider?.Value ?? 0f),
@@ -69,21 +74,35 @@ namespace VirtualMotionCaptureControlPanel
                 CG_Temperature = (float)(CG_Temperature_Slider?.Value ?? 0f),
                 CG_Saturation = (float)(CG_Saturation_Slider?.Value ?? 0f),
                 CG_Contrast = (float)(CG_Contrast_Slider?.Value ?? 0f),
+                CG_Gamma = (float)(CG_Gamma_Slider?.Value ?? 0f),
+                CG_ColorFilter_r = (float)((CG_ColorFilter_Button.Background as SolidColorBrush).Color.R / 255.0),
+                CG_ColorFilter_g = (float)((CG_ColorFilter_Button.Background as SolidColorBrush).Color.G / 255.0),
+                CG_ColorFilter_b = (float)((CG_ColorFilter_Button.Background as SolidColorBrush).Color.B / 255.0),
+                CG_ColorFilter_a = (float)((CG_ColorFilter_Button.Background as SolidColorBrush).Color.A / 255.0),
 
                 Vignette_Enable = Vignette_Enable_CheckBox?.IsChecked ?? false,
                 Vignette_Intensity = (float)(Vignette_Intensity_Slider?.Value ?? 0f),
                 Vignette_Smoothness = (float)(Vignette_Smoothness_Slider?.Value ?? 0f),
-                Vignette_Rounded = (float)(Vignette_Rounded_Slider?.Value ?? 0f),
+                Vignette_Roundness = (float)(Vignette_Roundness_Slider?.Value ?? 0f),
+                Vignette_Color_r = (float)((Vignette_Color_Button.Background as SolidColorBrush).Color.R / 255.0),
+                Vignette_Color_g = (float)((Vignette_Color_Button.Background as SolidColorBrush).Color.G / 255.0),
+                Vignette_Color_b = (float)((Vignette_Color_Button.Background as SolidColorBrush).Color.B / 255.0),
+                Vignette_Color_a = (float)((Vignette_Color_Button.Background as SolidColorBrush).Color.A / 255.0),
 
                 CA_Enable = CA_Enable_CheckBox?.IsChecked ?? false,
-                CA_Intensity = (float)(CA_Intensity_Slider?.Value ?? 0f)
+                CA_Intensity = (float)(CA_Intensity_Slider?.Value ?? 0f),
+                CA_FastMode = CA_FastMode_CheckBox?.IsChecked ?? false
             });
         }
-        private async void ValueApply(PipeCommands.SetPostProcessing d)
+        private void ValueApply(PipeCommands.SetAdvancedGraphicsOption d)
         {
             //postProcessingValueを画面に反映する
             Dispatcher.Invoke(() =>
             {
+                if (Global_Enable_CheckBox != null)
+                {
+                    Global_Enable_CheckBox.IsChecked = d.PPS_Enable;
+                }
                 if (Bloom_Enable_CheckBox != null)
                 {
                     Bloom_Enable_CheckBox.IsChecked = d.Bloom_Enable;
@@ -95,6 +114,10 @@ namespace VirtualMotionCaptureControlPanel
                 if (Bloom_Threshold_Slider != null)
                 {
                     Bloom_Threshold_Slider.Value = d.Bloom_Threshold;
+                }
+                if (Bloom_Color_Button != null) {
+                    Color c = Color.FromArgb((byte)(d.Bloom_Color_a * 255), (byte)(d.Bloom_Color_r * 255), (byte)(d.Bloom_Color_g * 255), (byte)(d.Bloom_Color_b * 255));
+                    Bloom_Color_Button.Background = new SolidColorBrush(c);
                 }
 
                 if (DoF_Enable_CheckBox != null)
@@ -134,6 +157,16 @@ namespace VirtualMotionCaptureControlPanel
                 {
                     CG_Contrast_Slider.Value = d.CG_Contrast;
                 }
+                if (CG_Gamma_Slider != null)
+                {
+                    CG_Gamma_Slider.Value = d.CG_Gamma;
+                }
+                if (CG_ColorFilter_Button != null)
+                {
+                    Color c = Color.FromArgb((byte)(d.CG_ColorFilter_a * 255), (byte)(d.CG_ColorFilter_r * 255), (byte)(d.CG_ColorFilter_g * 255), (byte)(d.CG_ColorFilter_b * 255));
+                    CG_ColorFilter_Button.Background = new SolidColorBrush(c);
+                }
+
 
                 if (Vignette_Enable_CheckBox != null)
                 {
@@ -147,10 +180,16 @@ namespace VirtualMotionCaptureControlPanel
                 {
                     Vignette_Smoothness_Slider.Value = d.Vignette_Smoothness;
                 }
-                if (Vignette_Rounded_Slider != null)
+                if (Vignette_Roundness_Slider != null)
                 {
-                    Vignette_Rounded_Slider.Value = d.Vignette_Rounded;
+                    Vignette_Roundness_Slider.Value = d.Vignette_Roundness;
                 }
+                if (Vignette_Color_Button != null)
+                {
+                    Color c = Color.FromArgb((byte)(d.Vignette_Color_a * 255), (byte)(d.Vignette_Color_r * 255), (byte)(d.Vignette_Color_g * 255), (byte)(d.Vignette_Color_b * 255));
+                    Vignette_Color_Button.Background = new SolidColorBrush(c);
+                }
+
 
                 if (CA_Enable_CheckBox != null)
                 {
@@ -160,6 +199,11 @@ namespace VirtualMotionCaptureControlPanel
                 {
                     CA_Intensity_Slider.Value = d.CA_Intensity;
                 }
+                if (CA_FastMode_CheckBox != null)
+                {
+                    CA_FastMode_CheckBox.IsChecked = d.CA_FastMode;
+                }
+
             });
 
         }
@@ -173,5 +217,71 @@ namespace VirtualMotionCaptureControlPanel
         {
             ValueChanged();
         }
+
+
+        private void CG_ColorFilter_Button_Clicked(object sender, RoutedEventArgs e)
+        {
+            var win = new ColorPickerWindow();
+            win.SelectedColor = (CG_ColorFilter_Button.Background as SolidColorBrush).Color;
+            win.SelectedColorChangedEvent += ColorPickerWindow_SelectedColorChanged_CG_ColorFilter;
+            win.Owner = this;
+            win.ShowDialog();
+            win.SelectedColorChangedEvent -= ColorPickerWindow_SelectedColorChanged_CG_ColorFilter;
+        }
+
+        private void ColorPickerWindow_SelectedColorChanged_CG_ColorFilter(object sender, Color e)
+        {
+            CG_ColorFilter_Button.Background = new SolidColorBrush(e);
+            ValueChanged();
+        }
+
+        private void Bloom_Color_Button_Clicked(object sender, RoutedEventArgs e)
+        {
+            var win = new ColorPickerWindow();
+            win.SelectedColor = (Bloom_Color_Button.Background as SolidColorBrush).Color;
+            win.SelectedColorChangedEvent += ColorPickerWindow_SelectedColorChanged_Bloom_Color;
+            win.Owner = this;
+            win.ShowDialog();
+            win.SelectedColorChangedEvent -= ColorPickerWindow_SelectedColorChanged_Bloom_Color;
+        }
+        private void ColorPickerWindow_SelectedColorChanged_Bloom_Color(object sender, Color e)
+        {
+            Bloom_Color_Button.Background = new SolidColorBrush(e);
+            ValueChanged();
+        }
+
+
+        private void Vignette_Color_Button_Clicked(object sender, RoutedEventArgs e)
+        {
+            var win = new ColorPickerWindow();
+            win.SelectedColor = (Vignette_Color_Button.Background as SolidColorBrush).Color;
+            win.SelectedColorChangedEvent += ColorPickerWindow_SelectedColorChanged_Vignette_Color_Button;
+            win.Owner = this;
+            win.ShowDialog();
+            win.SelectedColorChangedEvent -= ColorPickerWindow_SelectedColorChanged_Vignette_Color_Button;
+        }
+        private void ColorPickerWindow_SelectedColorChanged_Vignette_Color_Button(object sender, Color e)
+        {
+            Vignette_Color_Button.Background = new SolidColorBrush(e);
+            ValueChanged();
+        }
+
     }
 }
+/*
+         private void LightColorButton_Click(object sender, RoutedEventArgs e)
+        {
+            var win = new ColorPickerWindow();
+            win.SelectedColor = (LightColorButton.Background as SolidColorBrush).Color;
+            win.SelectedColorChangedEvent += ColorPickerWindow_SelectedColorChanged;
+            win.Owner = this;
+            win.ShowDialog();
+            win.SelectedColorChangedEvent -= ColorPickerWindow_SelectedColorChanged;
+        }
+
+        private async void ColorPickerWindow_SelectedColorChanged(object sender, Color e)
+        {
+            LightColorButton.Background = new SolidColorBrush(e);
+            await Globals.Client?.SendCommandAsync(new PipeCommands.ChangeLightColor { a = e.A / 255f, r = e.R / 255f, g = e.G / 255f, b = e.B / 255f });
+        }
+*/

--- a/ControlWindowWPF/ControlWindowWPF/GraphicsOptionWindow.xaml.cs
+++ b/ControlWindowWPF/ControlWindowWPF/GraphicsOptionWindow.xaml.cs
@@ -51,9 +51,9 @@ namespace VirtualMotionCaptureControlPanel
             if (Initializing) { return; }
             //セットされたpostProcessingValueを送信する
             await Globals.Client.SendCommandAsync(new PipeCommands.SetAdvancedGraphicsOption
-            { 
+            {
                 PPS_Enable = Global_Enable_CheckBox?.IsChecked ?? false,
-                
+
                 Bloom_Enable = Bloom_Enable_CheckBox?.IsChecked ?? false,
                 Bloom_Intensity = (float)Bloom_Intensity_Slider?.Value,
                 Bloom_Threshold = (float)Bloom_Threshold_Slider?.Value,
@@ -89,7 +89,9 @@ namespace VirtualMotionCaptureControlPanel
 
                 CA_Enable = CA_Enable_CheckBox?.IsChecked ?? false,
                 CA_Intensity = (float)(CA_Intensity_Slider?.Value ?? 0f),
-                CA_FastMode = CA_FastMode_CheckBox?.IsChecked ?? false
+                CA_FastMode = CA_FastMode_CheckBox?.IsChecked ?? false,
+
+                TurnOffAmbientLight = TurnOffAmbientLight_CheckBox?.IsChecked ?? false
             });
         }
         private void ValueApply(PipeCommands.SetAdvancedGraphicsOption d)
@@ -203,6 +205,11 @@ namespace VirtualMotionCaptureControlPanel
                 {
                     CA_FastMode_CheckBox.IsChecked = d.CA_FastMode;
                 }
+
+                if (TurnOffAmbientLight_CheckBox != null) {
+                    TurnOffAmbientLight_CheckBox.IsChecked = d.TurnOffAmbientLight;
+                }
+
                 Task.Delay(100);
                 Initializing = false;
             });

--- a/ControlWindowWPF/ControlWindowWPF/GraphicsOptionWindow.xaml.cs
+++ b/ControlWindowWPF/ControlWindowWPF/GraphicsOptionWindow.xaml.cs
@@ -29,9 +29,7 @@ namespace VirtualMotionCaptureControlPanel
         private async void Window_Loaded(object sender, RoutedEventArgs e)
         {
             Globals.Client.ReceivedEvent += Client_Received;
-
             await Globals.Client.SendCommandAsync(new PipeCommands.GetAdvancedGraphicsOption { });
-            Initializing = false;
         }
 
         private async void Window_Closing(object sender, System.ComponentModel.CancelEventArgs e)
@@ -99,6 +97,8 @@ namespace VirtualMotionCaptureControlPanel
             //postProcessingValueを画面に反映する
             Dispatcher.Invoke(() =>
             {
+                Initializing = true; //ループ防止
+
                 if (Global_Enable_CheckBox != null)
                 {
                     Global_Enable_CheckBox.IsChecked = d.PPS_Enable;
@@ -203,7 +203,8 @@ namespace VirtualMotionCaptureControlPanel
                 {
                     CA_FastMode_CheckBox.IsChecked = d.CA_FastMode;
                 }
-
+                Task.Delay(100);
+                Initializing = false;
             });
 
         }
@@ -266,22 +267,51 @@ namespace VirtualMotionCaptureControlPanel
             ValueChanged();
         }
 
-    }
-}
-/*
-         private void LightColorButton_Click(object sender, RoutedEventArgs e)
+        private void Bloom_Reset_Clicked(object sender, RoutedEventArgs e)
         {
-            var win = new ColorPickerWindow();
-            win.SelectedColor = (LightColorButton.Background as SolidColorBrush).Color;
-            win.SelectedColorChangedEvent += ColorPickerWindow_SelectedColorChanged;
-            win.Owner = this;
-            win.ShowDialog();
-            win.SelectedColorChangedEvent -= ColorPickerWindow_SelectedColorChanged;
+            Bloom_Intensity_Slider.Value = 2.7f;
+            Bloom_Threshold_Slider.Value = 0.5f;
+
+            Color c = Color.FromArgb(255,255,255,255);
+            Bloom_Color_Button.Background = new SolidColorBrush(c);
+            ValueChanged();
         }
 
-        private async void ColorPickerWindow_SelectedColorChanged(object sender, Color e)
+        private void DoF_Reset_Clicked(object sender, RoutedEventArgs e)
         {
-            LightColorButton.Background = new SolidColorBrush(e);
-            await Globals.Client?.SendCommandAsync(new PipeCommands.ChangeLightColor { a = e.A / 255f, r = e.R / 255f, g = e.G / 255f, b = e.B / 255f });
+            DoF_FocusDistance_Slider.Value = 1.65f;
+            DoF_Aperture_Slider.Value = 16f;
+            DoF_FocusLength_Slider.Value = 16.4f;
+            DoF_MaxBlurSize_Slider.Value = 3;
+            ValueChanged();
         }
-*/
+
+        private void CG_Reset_Clicked(object sender, RoutedEventArgs e)
+        {
+            CG_Temperature_Slider.Value = 0f;
+            CG_Saturation_Slider.Value = 0f;
+            CG_Contrast_Slider.Value = 0f;
+            CG_Gamma_Slider.Value = 0f;
+            Color c = Color.FromArgb(255,255,255,255);
+            CG_ColorFilter_Button.Background = new SolidColorBrush(c);
+            ValueChanged();
+        }
+
+        private void Vignette_Reset_Clicked(object sender, RoutedEventArgs e)
+        {
+            Vignette_Intensity_Slider.Value = 0.65f;
+            Vignette_Smoothness_Slider.Value = 0.35f;
+            Vignette_Roundness_Slider.Value = 1f;
+            Color c = Color.FromArgb(255,0,0,0);
+            Vignette_Color_Button.Background = new SolidColorBrush(c);
+            ValueChanged();
+        }
+
+        private void CA_Reset_Clicked(object sender, RoutedEventArgs e)
+        {
+            CA_Intensity_Slider.Value = 1f;
+            CA_FastMode_CheckBox.IsChecked = false;
+            ValueChanged();
+        }
+    }
+}

--- a/ControlWindowWPF/ControlWindowWPF/GraphicsOptionWindow.xaml.cs
+++ b/ControlWindowWPF/ControlWindowWPF/GraphicsOptionWindow.xaml.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Shapes;
+
+namespace VirtualMotionCaptureControlPanel
+{
+    /// <summary>
+    /// GraphicsOptionWindow.xaml の相互作用ロジック
+    /// </summary>
+    public partial class GraphicsOptionWindow : Window
+    {
+        public GraphicsOptionWindow()
+        {
+            InitializeComponent();
+        }
+
+        private void Window_Loaded(object sender, RoutedEventArgs e)
+        {
+
+        }
+
+        private void Window_Closing(object sender, System.ComponentModel.CancelEventArgs e)
+        {
+
+        }
+
+    }
+}

--- a/ControlWindowWPF/ControlWindowWPF/GraphicsOptionWindow.xaml.cs
+++ b/ControlWindowWPF/ControlWindowWPF/GraphicsOptionWindow.xaml.cs
@@ -20,6 +20,7 @@ namespace VirtualMotionCaptureControlPanel
     /// </summary>
     public partial class GraphicsOptionWindow : Window
     {
+        bool Initializing = true;
         public GraphicsOptionWindow()
         {
             InitializeComponent();
@@ -30,6 +31,7 @@ namespace VirtualMotionCaptureControlPanel
             Globals.Client.ReceivedEvent += Client_Received;
 
             await Globals.Client.SendCommandAsync(new PipeCommands.GetPostProcessing { });
+            Initializing = false;
         }
 
         private async void Window_Closing(object sender, System.ComponentModel.CancelEventArgs e)
@@ -48,9 +50,10 @@ namespace VirtualMotionCaptureControlPanel
 
         private async void ValueChanged()
         {
+            if (Initializing) { return; }
             //セットされたpostProcessingValueを送信する
             await Globals.Client.SendCommandAsync(new PipeCommands.SetPostProcessing { 
-                AntiAliasing_Enable = AntiAliasing_Enable_CheckBox.IsChecked.Value,
+                PPS_Enable = true, //暫定
                 
                 Bloom_Enable = Bloom_Enable_CheckBox?.IsChecked ?? false,
                 Bloom_Intensity = (float)Bloom_Intensity_Slider?.Value,
@@ -60,7 +63,7 @@ namespace VirtualMotionCaptureControlPanel
                 DoF_FocusDistance = (float)(DoF_FocusDistance_Slider?.Value ?? 0f),
                 DoF_Aperture = (float)(DoF_Aperture_Slider?.Value ?? 0f),
                 DoF_FocusLength = (float)(DoF_FocusLength_Slider?.Value ?? 0f),
-                DoF_MaxBlurSize = (float)(DoF_MaxBlurSize_Slider?.Value ?? 0f),
+                DoF_MaxBlurSize = (int)(DoF_MaxBlurSize_Slider?.Value ?? 0),
 
                 CG_Enable = CG_Enable_CheckBox?.IsChecked ?? false,
                 CG_Temperature = (float)(CG_Temperature_Slider?.Value ?? 0f),
@@ -79,30 +82,86 @@ namespace VirtualMotionCaptureControlPanel
         private async void ValueApply(PipeCommands.SetPostProcessing d)
         {
             //postProcessingValueを画面に反映する
-            AntiAliasing_Enable_CheckBox.IsChecked = d.AntiAliasing_Enable;
+            Dispatcher.Invoke(() =>
+            {
+                if (Bloom_Enable_CheckBox != null)
+                {
+                    Bloom_Enable_CheckBox.IsChecked = d.Bloom_Enable;
+                }
+                if (Bloom_Intensity_Slider != null)
+                {
+                    Bloom_Intensity_Slider.Value = d.Bloom_Intensity;
+                }
+                if (Bloom_Threshold_Slider != null)
+                {
+                    Bloom_Threshold_Slider.Value = d.Bloom_Threshold;
+                }
 
-            Bloom_Enable_CheckBox.IsChecked = d.Bloom_Enable;
-            Bloom_Intensity_Slider.Value = d.Bloom_Intensity;
-            Bloom_Threshold_Slider.Value = d.Bloom_Threshold;
+                if (DoF_Enable_CheckBox != null)
+                {
+                    DoF_Enable_CheckBox.IsChecked = d.DoF_Enable;
+                }
+                if (DoF_FocusDistance_Slider != null)
+                {
+                    DoF_FocusDistance_Slider.Value = d.DoF_FocusDistance;
+                }
+                if (DoF_Aperture_Slider != null)
+                {
+                    DoF_Aperture_Slider.Value = d.DoF_Aperture;
+                }
+                if (DoF_FocusLength_Slider != null)
+                {
+                    DoF_FocusLength_Slider.Value = d.DoF_FocusLength;
+                }
+                if (DoF_MaxBlurSize_Slider != null)
+                {
+                    DoF_MaxBlurSize_Slider.Value = d.DoF_MaxBlurSize;
+                }
 
-            DoF_Enable_CheckBox.IsChecked = d.DoF_Enable;
-            DoF_FocusDistance_Slider.Value = d.DoF_FocusDistance;
-            DoF_Aperture_Slider.Value = d.DoF_Aperture;
-            DoF_FocusLength_Slider.Value = d.DoF_FocusLength;
-            DoF_MaxBlurSize_Slider.Value = d.DoF_MaxBlurSize;
+                if (CG_Enable_CheckBox != null)
+                {
+                    CG_Enable_CheckBox.IsChecked = d.CG_Enable;
+                }
+                if (CG_Temperature_Slider != null)
+                {
+                    CG_Temperature_Slider.Value = d.CG_Temperature;
+                }
+                if (CG_Saturation_Slider != null)
+                {
+                    CG_Saturation_Slider.Value = d.CG_Saturation;
+                }
+                if (CG_Contrast_Slider != null)
+                {
+                    CG_Contrast_Slider.Value = d.CG_Contrast;
+                }
 
-            CG_Enable_CheckBox.IsChecked = d.CG_Enable;
-            CG_Temperature_Slider.Value = d.CG_Temperature;
-            CG_Saturation_Slider.Value = d.CG_Saturation;
-            CG_Contrast_Slider.Value = d.CG_Contrast;
+                if (Vignette_Enable_CheckBox != null)
+                {
+                    Vignette_Enable_CheckBox.IsChecked = d.Vignette_Enable;
+                }
+                if (Vignette_Intensity_Slider != null)
+                {
+                    Vignette_Intensity_Slider.Value = d.Vignette_Intensity;
+                }
+                if (Vignette_Smoothness_Slider != null)
+                {
+                    Vignette_Smoothness_Slider.Value = d.Vignette_Smoothness;
+                }
+                if (Vignette_Rounded_Slider != null)
+                {
+                    Vignette_Rounded_Slider.Value = d.Vignette_Rounded;
+                }
 
-            Vignette_Enable_CheckBox.IsChecked = d.Vignette_Enable;
-            Vignette_Intensity_Slider.Value = d.Vignette_Intensity;
-            Vignette_Smoothness_Slider.Value = d.Vignette_Smoothness;
-            Vignette_Rounded_Slider.Value = d.Vignette_Rounded;
+                if (CA_Enable_CheckBox != null)
+                {
+                    CA_Enable_CheckBox.IsChecked = d.CA_Enable;
+                }
+                if (CA_Intensity_Slider != null)
+                {
+                    CA_Intensity_Slider.Value = d.CA_Intensity;
+                }
+            });
 
-            CA_Enable_CheckBox.IsChecked = d.CA_Enable;
-            CA_Intensity_Slider.Value = d.CA_Intensity;
         }
 
         private void SliverValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e)

--- a/ControlWindowWPF/ControlWindowWPF/GraphicsOptionWindow.xaml.cs
+++ b/ControlWindowWPF/ControlWindowWPF/GraphicsOptionWindow.xaml.cs
@@ -52,26 +52,27 @@ namespace VirtualMotionCaptureControlPanel
             await Globals.Client.SendCommandAsync(new PipeCommands.SetPostProcessing { 
                 AntiAliasing_Enable = AntiAliasing_Enable_CheckBox.IsChecked.Value,
                 
-                Bloom_Enable = Bloom_Enable_CheckBox.IsChecked.Value,
+                Bloom_Enable = Bloom_Enable_CheckBox.IsChecked ?? false,
                 Bloom_Intensity = (float)Bloom_Intensity_Slider.Value,
+                Bloom_Threshold = (float)Bloom_Threshold_Slider.Value,
 
-                DoF_Enable = DoF_Enable_CheckBox.IsChecked.Value,
+                DoF_Enable = DoF_Enable_CheckBox.IsChecked ?? false,
                 DoF_FocusDistance = (float)DoF_FocusDistance_Slider.Value,
                 DoF_Aperture = (float)DoF_Aperture_Slider.Value,
                 DoF_FocusLength = (float)DoF_FocusLength_Slider.Value,
                 DoF_MaxBlurSize = (float)DoF_MaxBlurSize_Slider.Value,
 
-                CG_Enable = CG_Enable_CheckBox.IsChecked.Value,
+                CG_Enable = CG_Enable_CheckBox.IsChecked ?? false,
                 CG_Temperature = (float)CG_Temperature_Slider.Value,
                 CG_Saturation = (float)CG_Saturation_Slider.Value,
                 CG_Contrast = (float)CG_Contrast_Slider.Value,
 
-                Vignette_Enable = Vignette_Enable_CheckBox.IsChecked.Value,
+                Vignette_Enable = Vignette_Enable_CheckBox.IsChecked ?? false,
                 Vignette_Intensity = (float)Vignette_Intensity_Slider.Value,
                 Vignette_Smoothness = (float)Vignette_Smoothness_Slider.Value,
                 Vignette_Rounded = (float)Vignette_Rounded_Slider.Value,
 
-                CA_Enable = CA_Enable_CheckBox.IsChecked.Value,
+                CA_Enable = CA_Enable_CheckBox.IsChecked ?? false,
                 CA_Intensity = (float)CA_Intensity_Slider.Value
             });
         }
@@ -82,6 +83,7 @@ namespace VirtualMotionCaptureControlPanel
 
             Bloom_Enable_CheckBox.IsChecked = d.Bloom_Enable;
             Bloom_Intensity_Slider.Value = d.Bloom_Intensity;
+            Bloom_Threshold_Slider.Value = d.Bloom_Threshold;
 
             DoF_Enable_CheckBox.IsChecked = d.DoF_Enable;
             DoF_FocusDistance_Slider.Value = d.DoF_FocusDistance;

--- a/ControlWindowWPF/ControlWindowWPF/GraphicsOptionWindow.xaml.cs
+++ b/ControlWindowWPF/ControlWindowWPF/GraphicsOptionWindow.xaml.cs
@@ -20,8 +20,6 @@ namespace VirtualMotionCaptureControlPanel
     /// </summary>
     public partial class GraphicsOptionWindow : Window
     {
-        PipeCommands.SetPostProcessing postProcessingValue = new PipeCommands.SetPostProcessing();
-
         public GraphicsOptionWindow()
         {
             InitializeComponent();
@@ -44,20 +42,75 @@ namespace VirtualMotionCaptureControlPanel
             if (e.CommandType == typeof(PipeCommands.SetPostProcessing))
             {
                 var d = (PipeCommands.SetPostProcessing)e.Data;
-                postProcessingValue = d;
-                ValueApply();
+                ValueApply(d);
             }
         }
 
         private async void ValueChanged()
         {
             //セットされたpostProcessingValueを送信する
-            await Globals.Client.SendCommandAsync(postProcessingValue);
+            await Globals.Client.SendCommandAsync(new PipeCommands.SetPostProcessing { 
+                AntiAliasing_Enable = AntiAliasing_Enable_CheckBox.IsChecked.Value,
+                
+                Bloom_Enable = Bloom_Enable_CheckBox.IsChecked.Value,
+                Bloom_Intensity = (float)Bloom_Intensity_Slider.Value,
+
+                DoF_Enable = DoF_Enable_CheckBox.IsChecked.Value,
+                DoF_FocusDistance = (float)DoF_FocusDistance_Slider.Value,
+                DoF_Aperture = (float)DoF_Aperture_Slider.Value,
+                DoF_FocusLength = (float)DoF_FocusLength_Slider.Value,
+                DoF_MaxBlurSize = (float)DoF_MaxBlurSize_Slider.Value,
+
+                CG_Enable = CG_Enable_CheckBox.IsChecked.Value,
+                CG_Temperature = (float)CG_Temperature_Slider.Value,
+                CG_Saturation = (float)CG_Saturation_Slider.Value,
+                CG_Contrast = (float)CG_Contrast_Slider.Value,
+
+                Vignette_Enable = Vignette_Enable_CheckBox.IsChecked.Value,
+                Vignette_Intensity = (float)Vignette_Intensity_Slider.Value,
+                Vignette_Smoothness = (float)Vignette_Smoothness_Slider.Value,
+                Vignette_Rounded = (float)Vignette_Rounded_Slider.Value,
+
+                CA_Enable = CA_Enable_CheckBox.IsChecked.Value,
+                CA_Intensity = (float)CA_Intensity_Slider.Value
+            });
         }
-        private async void ValueApply()
+        private async void ValueApply(PipeCommands.SetPostProcessing d)
         {
             //postProcessingValueを画面に反映する
+            AntiAliasing_Enable_CheckBox.IsChecked = d.AntiAliasing_Enable;
+
+            Bloom_Enable_CheckBox.IsChecked = d.Bloom_Enable;
+            Bloom_Intensity_Slider.Value = d.Bloom_Intensity;
+
+            DoF_Enable_CheckBox.IsChecked = d.DoF_Enable;
+            DoF_FocusDistance_Slider.Value = d.DoF_FocusDistance;
+            DoF_Aperture_Slider.Value = d.DoF_Aperture;
+            DoF_FocusLength_Slider.Value = d.DoF_FocusLength;
+            DoF_MaxBlurSize_Slider.Value = d.DoF_MaxBlurSize;
+
+            CG_Enable_CheckBox.IsChecked = d.CG_Enable;
+            CG_Temperature_Slider.Value = d.CG_Temperature;
+            CG_Saturation_Slider.Value = d.CG_Saturation;
+            CG_Contrast_Slider.Value = d.CG_Contrast;
+
+            Vignette_Enable_CheckBox.IsChecked = d.Vignette_Enable;
+            Vignette_Intensity_Slider.Value = d.Vignette_Intensity;
+            Vignette_Smoothness_Slider.Value = d.Vignette_Smoothness;
+            Vignette_Rounded_Slider.Value = d.Vignette_Rounded;
+
+            CA_Enable_CheckBox.IsChecked = d.CA_Enable;
+            CA_Intensity_Slider.Value = d.CA_Intensity;
         }
 
+        private void SliverValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
+        {
+            ValueChanged();
+        }
+
+        private void Checked(object sender, RoutedEventArgs e)
+        {
+            ValueChanged();
+        }
     }
 }

--- a/ControlWindowWPF/ControlWindowWPF/GraphicsOptionWindow.xaml.cs
+++ b/ControlWindowWPF/ControlWindowWPF/GraphicsOptionWindow.xaml.cs
@@ -11,6 +11,7 @@ using System.Windows.Input;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using System.Windows.Shapes;
+using UnityMemoryMappedFile;
 
 namespace VirtualMotionCaptureControlPanel
 {
@@ -19,19 +20,43 @@ namespace VirtualMotionCaptureControlPanel
     /// </summary>
     public partial class GraphicsOptionWindow : Window
     {
+        PipeCommands.SetPostProcessing postProcessingValue = new PipeCommands.SetPostProcessing();
+
         public GraphicsOptionWindow()
         {
             InitializeComponent();
         }
 
-        private void Window_Loaded(object sender, RoutedEventArgs e)
+        private async void Window_Loaded(object sender, RoutedEventArgs e)
         {
+            Globals.Client.ReceivedEvent += Client_Received;
 
+            await Globals.Client.SendCommandAsync(new PipeCommands.GetPostProcessing { });
         }
 
-        private void Window_Closing(object sender, System.ComponentModel.CancelEventArgs e)
+        private async void Window_Closing(object sender, System.ComponentModel.CancelEventArgs e)
         {
+            Globals.Client.ReceivedEvent -= Client_Received;
+        }
 
+        private async void Client_Received(object sender, DataReceivedEventArgs e)
+        {
+            if (e.CommandType == typeof(PipeCommands.SetPostProcessing))
+            {
+                var d = (PipeCommands.SetPostProcessing)e.Data;
+                postProcessingValue = d;
+                ValueApply();
+            }
+        }
+
+        private async void ValueChanged()
+        {
+            //セットされたpostProcessingValueを送信する
+            await Globals.Client.SendCommandAsync(postProcessingValue);
+        }
+        private async void ValueApply()
+        {
+            //postProcessingValueを画面に反映する
         }
 
     }

--- a/ControlWindowWPF/ControlWindowWPF/MainWindow.xaml
+++ b/ControlWindowWPF/ControlWindowWPF/MainWindow.xaml
@@ -186,7 +186,7 @@
 								</DockPanel>
 							</StackPanel>
 						</GroupBox>
-						<Grid/>
+						<Button Content="Advanced Graphics Option" Name="GraphicsOptionButton" Click="GraphicsOptionButton_Click" Height="AUto"/>
 					</DockPanel>
 				</TabItem>
 				<TabItem Header="ヘルプ">

--- a/ControlWindowWPF/ControlWindowWPF/MainWindow.xaml.cs
+++ b/ControlWindowWPF/ControlWindowWPF/MainWindow.xaml.cs
@@ -721,9 +721,12 @@ namespace VirtualMotionCaptureControlPanel
 
         private void GraphicsOptionButton_Click(object sender, RoutedEventArgs e)
         {
-            var win = new GraphicsOptionWindow();
-            win.Owner = this;
-            win.ShowDialog();
+            //重複ウィンドウを許容しない
+            if (!Application.Current.Windows.OfType<GraphicsOptionWindow>().Any()) {
+                var win = new GraphicsOptionWindow();
+                win.Owner = this;
+                win.Show();
+            }
         }
 
         private void StatusBar_MouseDoubleClick(object sender, MouseButtonEventArgs e)

--- a/ControlWindowWPF/ControlWindowWPF/MainWindow.xaml.cs
+++ b/ControlWindowWPF/ControlWindowWPF/MainWindow.xaml.cs
@@ -719,6 +719,13 @@ namespace VirtualMotionCaptureControlPanel
             await Globals.Client?.SendCommandAsync(new PipeCommands.ChangeLightColor { a = e.A / 255f, r = e.R / 255f, g = e.G / 255f, b = e.B / 255f });
         }
 
+        private void GraphicsOptionButton_Click(object sender, RoutedEventArgs e)
+        {
+            var win = new GraphicsOptionWindow();
+            win.Owner = this;
+            win.ShowDialog();
+        }
+
         private void StatusBar_MouseDoubleClick(object sender, MouseButtonEventArgs e)
         {
             if (lastLog != null)

--- a/ControlWindowWPF/ControlWindowWPF/SettingWindow.xaml
+++ b/ControlWindowWPF/ControlWindowWPF/SettingWindow.xaml
@@ -92,12 +92,12 @@
                         <Button Content="VIVE Pro Eye" Name="EyeTracking_ViveProEyeSettingButton" Click="EyeTracking_ViveProEyeSettingButton_Click"/>
                     </UniformGrid>
                 </GroupBox>
-                <GroupBox Header="Lip Tracking (Experimental/Prototype)">
-                    <UniformGrid Columns="2">
-                        <Button Content="VIVE Lip Tracker" Name="LipTracking_ViveSettingButton" Click="LipTracking_ViveSettingButton_Click"/>
-                    </UniformGrid>
-                </GroupBox>
-                <GroupBox Header="{DynamicResource SettingWindow_Language}">
+				<GroupBox Header="Lip Tracking (Experimental/Prototype)">
+					<UniformGrid Columns="2">
+						<Button Content="VIVE Lip Tracker" Name="LipTracking_ViveSettingButton" Click="LipTracking_ViveSettingButton_Click"/>
+					</UniformGrid>
+				</GroupBox>
+				<GroupBox Header="{DynamicResource SettingWindow_Language}">
                     <ComboBox Name="LanguageComboBox" SelectedIndex="0" SelectionChanged="LanguageComboBox_SelectionChanged">
                         <system:String>Japanese</system:String>
                         <system:String>English</system:String>

--- a/ControlWindowWPF/ControlWindowWPF/VirtualMotionCaptureControlPanel.csproj
+++ b/ControlWindowWPF/ControlWindowWPF/VirtualMotionCaptureControlPanel.csproj
@@ -117,6 +117,9 @@
       <DependentUpon>FaceControlKeyAddWindow.xaml</DependentUpon>
     </Compile>
     <Compile Include="Globals.cs" />
+    <Compile Include="GraphicsOptionWindow.xaml.cs">
+      <DependentUpon>GraphicsOptionWindow.xaml</DependentUpon>
+    </Compile>
     <Compile Include="HandGestureControlKeyAddWindow.xaml.cs">
       <DependentUpon>HandGestureControlKeyAddWindow.xaml</DependentUpon>
     </Compile>
@@ -168,6 +171,10 @@
       <SubType>Designer</SubType>
     </Page>
     <Page Include="FaceControlKeyAddWindow.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="GraphicsOptionWindow.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -8,6 +8,7 @@
     "com.unity.ide.rider": "1.1.4",
     "com.unity.ide.vscode": "1.2.1",
     "com.unity.multiplayer-hlapi": "1.0.6",
+    "com.unity.postprocessing": "2.3.0",
     "com.unity.purchasing": "2.0.6",
     "com.unity.test-framework": "1.1.16",
     "com.unity.textmeshpro": "2.0.1",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -69,6 +69,13 @@
       },
       "url": "https://packages.unity.com"
     },
+    "com.unity.postprocessing": {
+      "version": "2.3.0",
+      "depth": 0,
+      "source": "registry",
+      "dependencies": {},
+      "url": "https://packages.unity.com"
+    },
     "com.unity.purchasing": {
       "version": "2.0.6",
       "depth": 0,

--- a/UnityMemoryMappedFile/PipeCommands.cs
+++ b/UnityMemoryMappedFile/PipeCommands.cs
@@ -513,6 +513,8 @@ namespace UnityMemoryMappedFile
             public float Vignette_Color_g { get; set; }
             public float Vignette_Color_b { get; set; }
 
+            public bool TurnOffAmbientLight { get; set; }
+
         }
 
         public class LogNotify {

--- a/UnityMemoryMappedFile/PipeCommands.cs
+++ b/UnityMemoryMappedFile/PipeCommands.cs
@@ -469,6 +469,34 @@ namespace UnityMemoryMappedFile
             public Dictionary<string, string> LipShapesToBlendShapeMap { get; set; }
         }
 
+        public class GetPostProcessing { }
+        public class SetPostProcessing
+        {
+            public bool AntiAliasing_Enable { get; set; }
+
+            public bool Bloom_Enable { get; set; }
+            public float Bloom_Intensity { get; set; }
+
+            public bool DoF_Enable { get; set; }
+            public float DoF_FocusDistance { get; set; }
+            public float DoF_Aperture { get; set; }
+            public float DoF_FocusLength { get; set; }
+            public float DoF_MaxBlurSize { get; set; }
+
+            public bool CG_Enable { get; set; }
+            public float CG_Temperature { get; set; }
+            public float CG_Saturation { get; set; }
+            public float CG_Contrast { get; set; }
+
+            public bool Vignette_Enable { get; set; }
+            public float Vignette_Intensity { get; set; }
+            public float Vignette_Smoothness { get; set; }
+            public float Vignette_Rounded { get; set; }
+
+            public bool CA_Enable { get; set; }
+            public float CA_Intensity { get; set; }
+        }
+
         public class LogNotify {
             public string condition { get; set; }
             public string stackTrace { get; set; }

--- a/UnityMemoryMappedFile/PipeCommands.cs
+++ b/UnityMemoryMappedFile/PipeCommands.cs
@@ -476,6 +476,7 @@ namespace UnityMemoryMappedFile
 
             public bool Bloom_Enable { get; set; }
             public float Bloom_Intensity { get; set; }
+            public float Bloom_Threshold { get; set; }
 
             public bool DoF_Enable { get; set; }
             public float DoF_FocusDistance { get; set; }

--- a/UnityMemoryMappedFile/PipeCommands.cs
+++ b/UnityMemoryMappedFile/PipeCommands.cs
@@ -472,8 +472,7 @@ namespace UnityMemoryMappedFile
         public class GetPostProcessing { }
         public class SetPostProcessing
         {
-            public bool AntiAliasing_Enable { get; set; }
-
+            public bool PPS_Enable { get; set; }
             public bool Bloom_Enable { get; set; }
             public float Bloom_Intensity { get; set; }
             public float Bloom_Threshold { get; set; }
@@ -482,7 +481,7 @@ namespace UnityMemoryMappedFile
             public float DoF_FocusDistance { get; set; }
             public float DoF_Aperture { get; set; }
             public float DoF_FocusLength { get; set; }
-            public float DoF_MaxBlurSize { get; set; }
+            public int DoF_MaxBlurSize { get; set; }
 
             public bool CG_Enable { get; set; }
             public float CG_Temperature { get; set; }

--- a/UnityMemoryMappedFile/PipeCommands.cs
+++ b/UnityMemoryMappedFile/PipeCommands.cs
@@ -469,8 +469,8 @@ namespace UnityMemoryMappedFile
             public Dictionary<string, string> LipShapesToBlendShapeMap { get; set; }
         }
 
-        public class GetPostProcessing { }
-        public class SetPostProcessing
+        public class GetAdvancedGraphicsOption { }
+        public class SetAdvancedGraphicsOption
         {
             public bool PPS_Enable { get; set; }
             public bool Bloom_Enable { get; set; }
@@ -487,14 +487,32 @@ namespace UnityMemoryMappedFile
             public float CG_Temperature { get; set; }
             public float CG_Saturation { get; set; }
             public float CG_Contrast { get; set; }
+            public float CG_Gamma { get; set; }
 
             public bool Vignette_Enable { get; set; }
             public float Vignette_Intensity { get; set; }
             public float Vignette_Smoothness { get; set; }
-            public float Vignette_Rounded { get; set; }
+            public float Vignette_Roundness { get; set; }
 
             public bool CA_Enable { get; set; }
             public float CA_Intensity { get; set; }
+            public bool CA_FastMode { get; set; }
+
+            public float Bloom_Color_a { get; set; }
+            public float Bloom_Color_r { get; set; }
+            public float Bloom_Color_g { get; set; }
+            public float Bloom_Color_b { get; set; }
+
+            public float CG_ColorFilter_a { get; set; }
+            public float CG_ColorFilter_r { get; set; }
+            public float CG_ColorFilter_g { get; set; }
+            public float CG_ColorFilter_b { get; set; }
+
+            public float Vignette_Color_a { get; set; }
+            public float Vignette_Color_r { get; set; }
+            public float Vignette_Color_g { get; set; }
+            public float Vignette_Color_b { get; set; }
+
         }
 
         public class LogNotify {


### PR DESCRIPTION
・PostProcessing機能を追加しました
・環境光をオフにできる機能を追加しました

シーンファイルの変更をコミットに含めていないため、以下の対応をお願いします。
・PostProcessingStack v2の導入
・各種カメラにPost-process Layerを設定。
　Voluime blendingのLayerはDefault
・GameObject「PostProcessing」を作成し、PostProcessingManagerをアタッチ
・ControlWPFWindowのPostProcessingManagerに上記をセット

※Post-process VolumeはPostProcessingManagerがランタイムで自動生成します。

![image](https://user-images.githubusercontent.com/33391403/93692617-67669700-fb30-11ea-8030-bc2e26f871dd.png)
![image](https://user-images.githubusercontent.com/33391403/93692619-6a618780-fb30-11ea-9df7-eaa00edf66ce.png)
