### PR TITLE
add link for vmc-protocol relation tools

### DIFF
--- a/docs/_data/navigation.yml
+++ b/docs/_data/navigation.yml
@@ -6,6 +6,10 @@
   link: /manual/
   new_window: false
   highlight: true
+- name: 連携ツール一覧
+  link: https://protocol.vmc.info/Reference
+  new_window: false
+  highlight: true
 - name: ダウンロード
   link: /download.html
   new_window: false


### PR DESCRIPTION
ヘッダに連携ツール一覧ボタンを追加

![スクリーンショット 2020-10-11 1 56 23](https://user-images.githubusercontent.com/639366/95660774-12350880-0b65-11eb-9af3-c88ff3754a85.png)
