### PR TITLE
デバイス探索対応

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ SteamVR*csproj
 Backup*
 Assets/ExternalPlugins/uOSC*
 Assets/ExternalPlugins/MidiJack*
+Assets/ExternalPlugins/EasyDeviceDiscoveryProtocol*
 
 # Visual Studio cache directory
 .vs/

--- a/Assets/ExternalSender/EasyDeviceDiscoveryProtocolManager.cs
+++ b/Assets/ExternalSender/EasyDeviceDiscoveryProtocolManager.cs
@@ -21,15 +21,17 @@ public class EasyDeviceDiscoveryProtocolManager : MonoBehaviour
     {
         requester = gameObject.AddComponent<Requester>();
         requester.deivceName = myname;
+        requester.ignoreDeivceName = myname;
+        requester.desktopMode = true;
 
         responder = gameObject.AddComponent<Responder>();
         responder.deivceName = myname;
+        responder.ignoreDeivceName = myname;
+        responder.desktopMode = true;
         responder.OnRequested = ()=> {
-            if (responder.requestDeviceName != myname) {
-                if(externalSender != null)
-                {
-                    externalSender.ChangeOSCAddress(responder.requestIpAddress, responder.requestServicePort);
-                }
+            if (externalSender != null)
+            {
+                externalSender.ChangeOSCAddress(responder.requestIpAddress, responder.requestServicePort);
             }
         };
     }
@@ -46,13 +48,11 @@ public class EasyDeviceDiscoveryProtocolManager : MonoBehaviour
             time += Time.deltaTime;
             if (time > 5.0)
             {
-                if (!found)
+                if (!found && externalReceiver.isActiveAndEnabled)
                 {
                     requester.servicePort = externalReceiver.receivePort;
                     requester.StartDiscover(() => {
-                        if (requester.deivceName != myname) {
-                            found = true;
-                        }
+                        found = true;
                     });
                 }
                 time = 0;

--- a/Assets/ExternalSender/EasyDeviceDiscoveryProtocolManager.cs
+++ b/Assets/ExternalSender/EasyDeviceDiscoveryProtocolManager.cs
@@ -1,0 +1,40 @@
+﻿//gpsnmeajp
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using EasyDeviceDiscoveryProtocolClient;
+
+public class EasyDeviceDiscoveryProtocolManager : MonoBehaviour
+{
+    public ExternalReceiverForVMC externalReceiver;
+    Requester requester;
+
+    public float time = 0;
+    public bool found = false;
+
+    void Start()
+    {
+        requester = gameObject.AddComponent<Requester>();
+        requester.deivceName = "Virtual Motion Capture";
+    }
+
+    void Update()
+    {
+        if (externalReceiver != null)
+        {
+            time += Time.deltaTime;
+            if (time > 5.0)
+            {
+                if (!found)
+                {
+                    requester.servicePort = externalReceiver.receivePort;
+                    requester.StartDiscover(() => {
+                        found = true;
+                    });
+                }
+                time = 0;
+            }
+        }
+    }
+}

--- a/Assets/ExternalSender/ExternalReceiverForVMC.cs
+++ b/Assets/ExternalSender/ExternalReceiverForVMC.cs
@@ -26,6 +26,8 @@ public class ExternalReceiverForVMC : MonoBehaviour {
     public string statusString = "";
     private string statusStringOld = "";
 
+    public EasyDeviceDiscoveryProtocolManager eddp;
+
     static public Action<string> StatusStringUpdated = null;
 
     ControlWPFWindow window = null;
@@ -404,6 +406,8 @@ public class ExternalReceiverForVMC : MonoBehaviour {
     public void ChangeOSCPort(int port)
     {
         receivePort = port;
+        eddp.found = false;
+
         var uServer = GetComponent<uOSC.uOscServer>();
         uServer.enabled = false;
         var type = typeof(uOSC.uOscServer);

--- a/Assets/ExternalSender/ExternalReceiverForVMC.cs
+++ b/Assets/ExternalSender/ExternalReceiverForVMC.cs
@@ -46,6 +46,8 @@ public class ExternalReceiverForVMC : MonoBehaviour {
     Vector3 pos;
     Quaternion rot;
 
+    public int packets = 0;
+
     private Dictionary<BlendShapeKey, float> blendShapeBuffer = new Dictionary<BlendShapeKey, float>();
 
     void Start () {
@@ -88,6 +90,12 @@ public class ExternalReceiverForVMC : MonoBehaviour {
         //有効なとき以外処理しない
         if (this.isActiveAndEnabled)
         {
+            //生存チェックのためのパケットカウンタ
+            packets++;
+            if (packets > int.MaxValue / 2) {
+                packets = 0;
+            }
+
             //仮想コントローラー V2.3
             if (message.address == "/VMC/Ext/Con/Pos"
                 && (message.values[0] is string)

--- a/Assets/Scripts/ControlWPFWindow.cs
+++ b/Assets/Scripts/ControlWPFWindow.cs
@@ -126,6 +126,8 @@ public class ControlWPFWindow : MonoBehaviour
 
     public string lastLoadedConfigPath = "";
 
+    public EasyDeviceDiscoveryProtocolManager easyDeviceDiscoveryProtocolManager;
+
     // Use this for initialization
     void Start()
     {
@@ -790,7 +792,8 @@ public class ControlWPFWindow : MonoBehaviour
             else if (e.CommandType == typeof(PipeCommands.ChangeExternalMotionSenderAddress))
             {
                 var d = (PipeCommands.ChangeExternalMotionSenderAddress)e.Data;
-                ChangeExternalMotionSenderAddress(d.address, d.port, d.PeriodStatus, d.PeriodRoot, d.PeriodBone, d.PeriodBlendShape, d.PeriodCamera, d.PeriodDevices, d.OptionString);
+                ChangeExternalMotionSenderAddress(d.address, d.port, d.PeriodStatus, d.PeriodRoot, d.PeriodBone, d.PeriodBlendShape, d.PeriodCamera, d.PeriodDevices, d.OptionString, d.ResponderEnable);
+
             }
             else if (e.CommandType == typeof(PipeCommands.GetExternalMotionSenderAddress))
             {
@@ -805,6 +808,7 @@ public class ControlWPFWindow : MonoBehaviour
                     PeriodCamera = CurrentSettings.ExternalMotionSenderPeriodCamera,
                     PeriodDevices = CurrentSettings.ExternalMotionSenderPeriodDevices,
                     OptionString = CurrentSettings.ExternalMotionSenderOptionString,
+                    ResponderEnable = CurrentSettings.ExternalMotionSenderResponderEnable
                 }, e.RequestId);
             }
             else if (e.CommandType == typeof(PipeCommands.EnableExternalMotionReceiver))
@@ -822,13 +826,15 @@ public class ControlWPFWindow : MonoBehaviour
             else if (e.CommandType == typeof(PipeCommands.ChangeExternalMotionReceiverPort))
             {
                 var d = (PipeCommands.ChangeExternalMotionReceiverPort)e.Data;
-                ChangeExternalMotionReceiverPort(d.port);
+                ChangeExternalMotionReceiverPort(d.port, d.RequesterEnable);
+
             }
             else if (e.CommandType == typeof(PipeCommands.GetExternalMotionReceiverPort))
             {
                 await server.SendCommandAsync(new PipeCommands.ChangeExternalMotionReceiverPort
                 {
-                    port = CurrentSettings.ExternalMotionReceiverPort
+                    port = CurrentSettings.ExternalMotionReceiverPort,
+                    RequesterEnable = CurrentSettings.ExternalMotionReceiverRequesterEnable
                 }, e.RequestId);
             }
             else if (e.CommandType == typeof(PipeCommands.GetMidiCCBlendShape))
@@ -2528,7 +2534,7 @@ public class ControlWPFWindow : MonoBehaviour
         WaitOneFrameAction(() => CameraChangedAction?.Invoke(ControlCamera));
     }
 
-    private void ChangeExternalMotionSenderAddress(string address, int port, int pstatus, int proot, int pbone, int pblendshape, int pcamera, int pdevices, string optionstring)
+    private void ChangeExternalMotionSenderAddress(string address, int port, int pstatus, int proot, int pbone, int pblendshape, int pcamera, int pdevices, string optionstring, bool responderEnable)
     {
         CurrentSettings.ExternalMotionSenderAddress = address;
         CurrentSettings.ExternalMotionSenderPort = port;
@@ -2539,6 +2545,8 @@ public class ControlWPFWindow : MonoBehaviour
         CurrentSettings.ExternalMotionSenderPeriodCamera = pcamera;
         CurrentSettings.ExternalMotionSenderPeriodDevices = pdevices;
         CurrentSettings.ExternalMotionSenderOptionString = optionstring;
+        CurrentSettings.ExternalMotionSenderResponderEnable = responderEnable;
+
         externalMotionSender.periodStatus = pstatus;
         externalMotionSender.periodRoot = proot;
         externalMotionSender.periodBone = pbone;
@@ -2547,14 +2555,25 @@ public class ControlWPFWindow : MonoBehaviour
         externalMotionSender.periodDevices = pdevices;
         externalMotionSender.ChangeOSCAddress(address, port);
         externalMotionSender.optionString = optionstring;
+        easyDeviceDiscoveryProtocolManager.responderEnable = responderEnable;
     }
 
-    private void ChangeExternalMotionReceiverPort(int port)
+    public void ChangeExternalMotionSenderAddress(string address, int port)
+    {
+        CurrentSettings.ExternalMotionSenderAddress = address;
+        CurrentSettings.ExternalMotionSenderPort = port;
+
+        externalMotionSender.ChangeOSCAddress(address, port);
+    }
+
+    private void ChangeExternalMotionReceiverPort(int port, bool requesterEnable)
     {
         CurrentSettings.ExternalMotionReceiverPort = port;
         externalMotionReceiver.ChangeOSCPort(port);
-    }
 
+        CurrentSettings.ExternalMotionReceiverRequesterEnable = requesterEnable;
+        easyDeviceDiscoveryProtocolManager.requesterEnable = requesterEnable;
+    }
 
     private void WaitOneFrameAction(Action action)
     {
@@ -2876,9 +2895,13 @@ public class ControlWPFWindow : MonoBehaviour
         [OptionalField]
         public int ExternalMotionSenderPeriodDevices;
         [OptionalField]
+        public bool ExternalMotionSenderResponderEnable;
+        [OptionalField]
         public bool ExternalMotionReceiverEnable;
         [OptionalField]
         public int ExternalMotionReceiverPort;
+        [OptionalField]
+        public bool ExternalMotionReceiverRequesterEnable;
         [OptionalField]
         public string ExternalMotionSenderOptionString;
         [OptionalField]
@@ -2980,11 +3003,13 @@ public class ControlWPFWindow : MonoBehaviour
             ExternalMotionSenderPeriodCamera = 1;
             ExternalMotionSenderPeriodDevices = 1;
             ExternalMotionSenderOptionString = "";
+            ExternalMotionSenderResponderEnable = false;
 
             ExternalMotionReceiverEnable = false;
             ExternalMotionReceiverPort = 39540;
+            ExternalMotionReceiverRequesterEnable = true;
 
-            MidiCCBlendShape = new List<string>(Enumerable.Repeat(default(string), MidiCCWrapper.KNOBS));
+           MidiCCBlendShape = new List<string>(Enumerable.Repeat(default(string), MidiCCWrapper.KNOBS));
 
             LipShapesToBlendShapeMap = new Dictionary<string, string>();
 
@@ -3344,9 +3369,9 @@ public class ControlWPFWindow : MonoBehaviour
         ChangeLightColor(CurrentSettings.LightColor.a, CurrentSettings.LightColor.r, CurrentSettings.LightColor.g, CurrentSettings.LightColor.b);
 
         SetExternalMotionSenderEnable(CurrentSettings.ExternalMotionSenderEnable);
-        ChangeExternalMotionSenderAddress(CurrentSettings.ExternalMotionSenderAddress, CurrentSettings.ExternalMotionSenderPort, CurrentSettings.ExternalMotionSenderPeriodStatus, CurrentSettings.ExternalMotionSenderPeriodRoot, CurrentSettings.ExternalMotionSenderPeriodBone, CurrentSettings.ExternalMotionSenderPeriodBlendShape, CurrentSettings.ExternalMotionSenderPeriodCamera, CurrentSettings.ExternalMotionSenderPeriodDevices, CurrentSettings.ExternalMotionSenderOptionString);
+        ChangeExternalMotionSenderAddress(CurrentSettings.ExternalMotionSenderAddress, CurrentSettings.ExternalMotionSenderPort, CurrentSettings.ExternalMotionSenderPeriodStatus, CurrentSettings.ExternalMotionSenderPeriodRoot, CurrentSettings.ExternalMotionSenderPeriodBone, CurrentSettings.ExternalMotionSenderPeriodBlendShape, CurrentSettings.ExternalMotionSenderPeriodCamera, CurrentSettings.ExternalMotionSenderPeriodDevices, CurrentSettings.ExternalMotionSenderOptionString, CurrentSettings.ExternalMotionSenderResponderEnable);
         SetExternalMotionReceiverEnable(CurrentSettings.ExternalMotionReceiverEnable);
-        ChangeExternalMotionReceiverPort(CurrentSettings.ExternalMotionReceiverPort);
+        ChangeExternalMotionReceiverPort(CurrentSettings.ExternalMotionReceiverPort, CurrentSettings.ExternalMotionReceiverRequesterEnable);
 
         SetMidiCCBlendShape(CurrentSettings.MidiCCBlendShape);
 

--- a/ControlWindowWPF/ControlWindowWPF/Resources/Chinese.xaml
+++ b/ControlWindowWPF/ControlWindowWPF/Resources/Chinese.xaml
@@ -253,7 +253,8 @@
 	<system:String x:Key="SettingWindow_VirtualMotionTrackerEnable">Enable</system:String>
 	<system:String x:Key="SettingWindow_VirtualMotionTrackerInstallSuccess">Success! Restart SteamVR and VirtualMotionCapture. Press OK and wait auto restart.</system:String>
 	<system:String x:Key="SettingWindow_VMTContinue">Continue VMT setup? Game will be interrupted, and VR system will restart.</system:String>
-    
+    <system:String x:Key="SettingWindow_ExternalMotionSenderResponderEnable">Allow device detection response</system:String>
+	<system:String x:Key="SettingWindow_ExternalMotionReceiverRequesterEnable">Auto device detection</system:String>
 
     <!-- TrackerConfigWindow -->
     <system:String x:Key="TrackerConfigWindowTitle">追踪器详细设置</system:String>

--- a/ControlWindowWPF/ControlWindowWPF/Resources/English.xaml
+++ b/ControlWindowWPF/ControlWindowWPF/Resources/English.xaml
@@ -253,6 +253,8 @@
 	<system:String x:Key="SettingWindow_VirtualMotionTrackerEnable">Enable</system:String>
 	<system:String x:Key="SettingWindow_VirtualMotionTrackerInstallSuccess">Success! Restart SteamVR and VirtualMotionCapture. Press OK and wait auto restart.</system:String>
 	<system:String x:Key="SettingWindow_VMTContinue">Continue VMT setup? Game will be interrupted, and VR system will restart.</system:String>
+    <system:String x:Key="SettingWindow_ExternalMotionSenderResponderEnable">Allow device detection response</system:String>
+	<system:String x:Key="SettingWindow_ExternalMotionReceiverRequesterEnable">Auto device detection</system:String>
 
 
     <!-- TrackerConfigWindow -->

--- a/ControlWindowWPF/ControlWindowWPF/Resources/Japanese.xaml
+++ b/ControlWindowWPF/ControlWindowWPF/Resources/Japanese.xaml
@@ -254,6 +254,9 @@
     <system:String x:Key="SettingWindow_VirtualMotionTrackerEnable">有効</system:String>
     <system:String x:Key="SettingWindow_VirtualMotionTrackerInstallSuccess">成功しました。SteamVRとバーチャルモーションキャプチャーが自動で再起動されますので、OKを押してしばらくお待ちください。</system:String>
 	<system:String x:Key="SettingWindow_VMTContinue">VMTのセットアップを実行しますか？ゲームが中断され、VRシステムは自動で再起動します。</system:String>
+	<system:String x:Key="SettingWindow_ExternalMotionSenderResponderEnable">デバイス探索要求への応答を許可</system:String>
+	<system:String x:Key="SettingWindow_ExternalMotionReceiverRequesterEnable">自動デバイス探索を行う</system:String>
+
 
 	<!-- TrackerConfigWindow -->
     <system:String x:Key="TrackerConfigWindowTitle">トラッカー割り当て設定</system:String>

--- a/ControlWindowWPF/ControlWindowWPF/Resources/Korean.xaml
+++ b/ControlWindowWPF/ControlWindowWPF/Resources/Korean.xaml
@@ -254,8 +254,10 @@
     <system:String x:Key="SettingWindow_VirtualMotionTrackerEnable">Enable</system:String>
     <system:String x:Key="SettingWindow_VirtualMotionTrackerInstallSuccess">Success! Restart SteamVR and VirtualMotionCapture. Press OK and wait auto restart.</system:String>
 	<system:String x:Key="SettingWindow_VMTContinue">Continue VMT setup? Game will be interrupted, and VR system will restart.</system:String>
+	<system:String x:Key="SettingWindow_ExternalMotionSenderResponderEnable">Allow device detection response</system:String>
+	<system:String x:Key="SettingWindow_ExternalMotionReceiverRequesterEnable">Auto device detection</system:String>
 
-    <!-- TrackerConfigWindow -->
+	<!-- TrackerConfigWindow -->
     <system:String x:Key="TrackerConfigWindowTitle">트래커 할당 설정</system:String>
 
     <system:String x:Key="TrackerConfigWindow_TrackerConfig">트래커 할당</system:String>

--- a/ControlWindowWPF/ControlWindowWPF/SettingWindow.xaml
+++ b/ControlWindowWPF/ControlWindowWPF/SettingWindow.xaml
@@ -171,7 +171,8 @@
                             <TextBlock Text="Option: " Grid.Column="0"/>
                             <TextBox Text="" Grid.Column="1" VerticalAlignment="Center" Name="OptionStringTextbox"/>
                         </Grid>
-                    </DockPanel>
+						<CheckBox Content="{DynamicResource SettingWindow_ExternalMotionSenderResponderEnable}" Name="ExternalMotionSenderResponderEnableCheckBox" DockPanel.Dock="Top"/>
+					</DockPanel>
                 </GroupBox>
                 <GroupBox>
                     <GroupBox.Header>
@@ -181,7 +182,7 @@
                                 <TextBlock Text=" IP:"/>
                                 <Button Content="Check IP" Name="CheckIPAddressButton" Click="CheckIPAddressButton_Click" Padding="5,0" Margin="5,1" Height="Auto"/>
                             </StackPanel>
-                        </WrapPanel>
+						</WrapPanel>
                     </GroupBox.Header>
                     <DockPanel>
                         <Button Content="{DynamicResource SettingWindow_ResolutionApply}" Name="OSCReceiverApplyButton" Click="OSCReceiverApplyButton_Click" DockPanel.Dock="Right" Padding="10,5"/>
@@ -200,7 +201,8 @@
                             <TextBlock Text="Status: " Grid.Column="0" Grid.Row="1"/>
                             <TextBox Text="" Grid.Column="1" Grid.Row="1" IsReadOnly="True" IsEnabled="False" VerticalAlignment="Center" Name="StatusStringTextbox"/>
                         </Grid>
-                    </DockPanel>
+						<CheckBox Content="{DynamicResource SettingWindow_ExternalMotionReceiverRequesterEnable}" Name="ExternalMotionReceiverRequesterEnableCheckBox" DockPanel.Dock="Top"/>
+					</DockPanel>
                 </GroupBox>
                 <GroupBox Header="{DynamicResource SettingWindow_MIDI_CC_BlendShape}">
                     <Button Content="{DynamicResource SettingWindow_MidiCCBlendShapeSetting}" Name="MidiCCBlendShapeSettingButton" Click="MidiCCBlendShapeSettingButton_Click"/>

--- a/ControlWindowWPF/ControlWindowWPF/SettingWindow.xaml.cs
+++ b/ControlWindowWPF/ControlWindowWPF/SettingWindow.xaml.cs
@@ -304,6 +304,7 @@ namespace VirtualMotionCaptureControlPanel
                     PeriodCameraTextBox.Text = data.PeriodCamera.ToString();
                     PeriodDevicesTextBox.Text = data.PeriodDevices.ToString();
                     OptionStringTextbox.Text = data.OptionString;
+                    ExternalMotionSenderResponderEnableCheckBox.IsChecked = data.ResponderEnable;
                 });
             });
             await Globals.Client?.SendCommandWaitAsync(new PipeCommands.GetEnableExternalMotionReceiver { }, d =>
@@ -323,6 +324,7 @@ namespace VirtualMotionCaptureControlPanel
                 {
                     isSetting = true;
                     ExternalMotionReceiverPortTextBox.Text = data.port.ToString();
+                    ExternalMotionReceiverRequesterEnableCheckBox.IsChecked = data.RequesterEnable;
                     isSetting = false;
                 });
             });
@@ -649,6 +651,7 @@ namespace VirtualMotionCaptureControlPanel
                     PeriodCamera = PeriodCamera.Value,
                     PeriodDevices = PeriodDevices.Value,
                     OptionString = OptionStringTextbox.Text,
+                    ResponderEnable = ExternalMotionSenderResponderEnableCheckBox.IsChecked.Value
                 });
             }
         }
@@ -669,7 +672,8 @@ namespace VirtualMotionCaptureControlPanel
             {
                 await Globals.Client?.SendCommandAsync(new PipeCommands.ChangeExternalMotionReceiverPort
                 {
-                    port = port.Value
+                    port = port.Value,
+                    RequesterEnable = ExternalMotionReceiverRequesterEnableCheckBox.IsChecked.Value
                 });
             }
         }

--- a/UnityMemoryMappedFile/PipeCommands.cs
+++ b/UnityMemoryMappedFile/PipeCommands.cs
@@ -379,6 +379,7 @@ namespace UnityMemoryMappedFile
             public int PeriodDevices { get; set; }
 
             public string OptionString { get; set; } //OK
+            public bool ResponderEnable { get; set; } 
         }
 
         public class GetEnableExternalMotionReceiver { }
@@ -390,6 +391,7 @@ namespace UnityMemoryMappedFile
         public class ChangeExternalMotionReceiverPort
         {
             public int port { get; set; }
+            public bool RequesterEnable { get; set; }
         }
         public class GetMidiCCBlendShape { }
         public class SetMidiCCBlendShape


### PR DESCRIPTION
デバイス探索(EasyDeviceDiscoveryProtocolForUnity)に対応しました。
・(探索要求)wiadayoなどに見つけてもらうこと
・(探索受付)Oredayo4V, 4Mなどを見つけること
ができるようになります。

例のごとくシーンファイルを含まないPRです。

＊シーンの編集
・[EasyDeviceDiscoveryProtocolForUnity_v002 のUnityPackage](https://github.com/gpsnmeajp/EasyDeviceDiscoveryProtocolForUnity/releases/tag/v0.02)を導入してください。
・Manager配下に、EasyDeviceDiscoveryProtocolManagerというオブジェクトを作り、
　EasyDeviceDiscoveryProtocolManagerをアタッチしてください
・EasyDeviceDiscoveryProtocolManagerに、
　・ControlWPFWindow
　・ExternalSender
　・ExternalReceiverForVMC
　を割り当ててください。
・ControlWPFWindowに、EasyDeviceDiscoveryProtocolManagerを割り当ててください。
・ExternalReceiverForVMCに、EasyDeviceDiscoveryProtocolManagerを割り当ててください。

![image](https://user-images.githubusercontent.com/33391403/99877728-8faf6680-2c43-11eb-9a52-84693767713c.png)
