### PR TITLE
表情制御設定にOSC受信のBlendShape無効処理を追加

### DIFF
--- a/Assets/ExternalSender/ExternalReceiverForVMC.cs
+++ b/Assets/ExternalSender/ExternalReceiverForVMC.cs
@@ -69,6 +69,8 @@ public class ExternalReceiverForVMC : MonoBehaviour
 
     private Dictionary<string, float> blendShapeBuffer = new Dictionary<string, float>();
 
+    public bool DisableBlendShapeReception { get; set; }
+
     void Start()
     {
         var server = GetComponent<uOSC.uOscServer>();
@@ -245,7 +247,7 @@ public class ExternalReceiverForVMC : MonoBehaviour
             //ブレンドシェープ適用
             else if (message.address == "/VMC/Ext/Blend/Apply")
             {
-                if (!window.IsKeyActions())
+                if (DisableBlendShapeReception == false)
                 {
                     faceController.MixPresets(nameof(ExternalReceiverForVMC), blendShapeBuffer.Keys.ToArray(), blendShapeBuffer.Values.ToArray());
                 }

--- a/Assets/ExternalSender/ExternalReceiverForVMC.cs
+++ b/Assets/ExternalSender/ExternalReceiverForVMC.cs
@@ -245,7 +245,10 @@ public class ExternalReceiverForVMC : MonoBehaviour
             //ブレンドシェープ適用
             else if (message.address == "/VMC/Ext/Blend/Apply")
             {
-                faceController.MixPresets(nameof(ExternalReceiverForVMC), blendShapeBuffer.Keys.ToArray(), blendShapeBuffer.Values.ToArray());
+                if (!window.IsKeyActions())
+                {
+                    faceController.MixPresets(nameof(ExternalReceiverForVMC), blendShapeBuffer.Keys.ToArray(), blendShapeBuffer.Values.ToArray());
+                }
                 blendShapeBuffer.Clear();
 
             }//外部アイトラ V2.3

--- a/Assets/Scripts/ControlWPFWindow.cs
+++ b/Assets/Scripts/ControlWPFWindow.cs
@@ -2626,6 +2626,11 @@ public class ControlWPFWindow : MonoBehaviour
 
     private List<KeyConfig> CurrentKeyConfigs = new List<KeyConfig>();
     private List<KeyAction> CurrentKeyUpActions = new List<KeyAction>();
+    private bool CurrentKeyDown_StopReceptionBlendShape;
+    public bool IsKeyActions()
+    {
+        return CurrentKeyUpActions.Where(d => d.StopReceptionBlendShape).Any() || CurrentKeyDown_StopReceptionBlendShape;
+    }
 
     private void CheckKey(KeyConfig config, bool isKeyDown)
     {
@@ -2766,6 +2771,7 @@ public class ControlWPFWindow : MonoBehaviour
         }
         else if (action.FaceAction)
         {
+            CurrentKeyDown_StopReceptionBlendShape = action.StopReceptionBlendShape;
             LipSync.MaxLevel = action.LipSyncMaxLevel;
             faceController.SetFace(action.FaceNames, action.FaceStrength, action.StopBlink);
         }

--- a/Assets/Scripts/ControlWPFWindow.cs
+++ b/Assets/Scripts/ControlWPFWindow.cs
@@ -2626,11 +2626,6 @@ public class ControlWPFWindow : MonoBehaviour
 
     private List<KeyConfig> CurrentKeyConfigs = new List<KeyConfig>();
     private List<KeyAction> CurrentKeyUpActions = new List<KeyAction>();
-    private bool CurrentKeyDown_StopReceptionBlendShape;
-    public bool IsKeyActions()
-    {
-        return CurrentKeyUpActions.Where(d => d.StopReceptionBlendShape).Any() || CurrentKeyDown_StopReceptionBlendShape;
-    }
 
     private void CheckKey(KeyConfig config, bool isKeyDown)
     {
@@ -2771,7 +2766,7 @@ public class ControlWPFWindow : MonoBehaviour
         }
         else if (action.FaceAction)
         {
-            CurrentKeyDown_StopReceptionBlendShape = action.StopReceptionBlendShape;
+            externalMotionReceiver.DisableBlendShapeReception = action.DisableBlendShapeReception;
             LipSync.MaxLevel = action.LipSyncMaxLevel;
             faceController.SetFace(action.FaceNames, action.FaceStrength, action.StopBlink);
         }

--- a/ControlWindowWPF/ControlWindowWPF/FaceControlKeyAddWindow.xaml
+++ b/ControlWindowWPF/ControlWindowWPF/FaceControlKeyAddWindow.xaml
@@ -5,7 +5,7 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:VirtualMotionCaptureControlPanel"
         mc:Ignorable="d"
-        Title="{DynamicResource FaceControlKeyAddWindowTitle}" Height="350" Width="800" Loaded="Window_Loaded" Closing="Window_Closing" Icon="Resources/VirtualMotionCapture_dark.ico">
+        Title="{DynamicResource FaceControlKeyAddWindowTitle}" Height="374" Width="800" Loaded="Window_Loaded" Closing="Window_Closing" Icon="Resources/VirtualMotionCapture_dark.ico">
     <DockPanel>
         <GroupBox Header="{DynamicResource FaceControlKeyAddWindow_UseKey}" DockPanel.Dock="Top">
             <DockPanel>
@@ -22,6 +22,7 @@
                 </StackPanel>
             </GroupBox>
             <CheckBox HorizontalAlignment="Right" DockPanel.Dock="Top" Content="{DynamicResource FaceControlKeyAddWindow_DisableBlinking}" Name="AutoBlinkCheckBox"/>
+            <CheckBox Content="{DynamicResource FaceControlKeyAddWindow_DisableBlendShape}" DockPanel.Dock="Top" HorizontalAlignment="Right" Name="DisableBlendShape"/>
             <GroupBox Header="{DynamicResource FaceControlKeyAddWindow_LipSyncSuppression}" DockPanel.Dock="Top">
                 <StackPanel Orientation="Vertical">
                     <DockPanel Margin="0,5,0,0">

--- a/ControlWindowWPF/ControlWindowWPF/FaceControlKeyAddWindow.xaml
+++ b/ControlWindowWPF/ControlWindowWPF/FaceControlKeyAddWindow.xaml
@@ -22,7 +22,7 @@
                 </StackPanel>
             </GroupBox>
             <CheckBox HorizontalAlignment="Right" DockPanel.Dock="Top" Content="{DynamicResource FaceControlKeyAddWindow_DisableBlinking}" Name="AutoBlinkCheckBox"/>
-            <CheckBox Content="{DynamicResource FaceControlKeyAddWindow_DisableBlendShape}" DockPanel.Dock="Top" HorizontalAlignment="Right" Name="DisableBlendShape"/>
+            <CheckBox HorizontalAlignment="Right" DockPanel.Dock="Top" Content="{DynamicResource FaceControlKeyAddWindow_DisableBlendShapeReception}"  Name="DisableBlendShapeCheckBox"/>
             <GroupBox Header="{DynamicResource FaceControlKeyAddWindow_LipSyncSuppression}" DockPanel.Dock="Top">
                 <StackPanel Orientation="Vertical">
                     <DockPanel Margin="0,5,0,0">

--- a/ControlWindowWPF/ControlWindowWPF/FaceControlKeyAddWindow.xaml.cs
+++ b/ControlWindowWPF/ControlWindowWPF/FaceControlKeyAddWindow.xaml.cs
@@ -35,6 +35,7 @@ namespace VirtualMotionCaptureControlPanel
             LipSyncMaxLevelTextBlock.Text = action.LipSyncMaxLevel.ToString("0.00");
             LipSyncMaxLevelSlider.Value = action.LipSyncMaxLevel;
             AutoBlinkCheckBox.IsChecked = action.StopBlink;
+            DisableBlendShape.IsChecked = action.StopReceptionBlendShape;
             CustomNameTextBox.Text = action.Name;
             KeyUpCheckBox.IsChecked = action.IsKeyUp;
             KeyConfigs.AddRange(action.KeyConfigs);
@@ -155,6 +156,7 @@ namespace VirtualMotionCaptureControlPanel
             action.FaceNames = faceItems.Select(d => d.Key).ToList();
             action.FaceStrength = faceItems.Select(d => d.Value).ToList();
             action.StopBlink = AutoBlinkCheckBox.IsChecked.Value;
+            action.StopReceptionBlendShape = DisableBlendShape.IsChecked.Value;
             action.IsKeyUp = KeyUpCheckBox.IsChecked.Value;
             action.LipSyncMaxLevel = (float)LipSyncMaxLevelSlider.Value;
 

--- a/ControlWindowWPF/ControlWindowWPF/FaceControlKeyAddWindow.xaml.cs
+++ b/ControlWindowWPF/ControlWindowWPF/FaceControlKeyAddWindow.xaml.cs
@@ -35,7 +35,7 @@ namespace VirtualMotionCaptureControlPanel
             LipSyncMaxLevelTextBlock.Text = action.LipSyncMaxLevel.ToString("0.00");
             LipSyncMaxLevelSlider.Value = action.LipSyncMaxLevel;
             AutoBlinkCheckBox.IsChecked = action.StopBlink;
-            DisableBlendShape.IsChecked = action.StopReceptionBlendShape;
+            DisableBlendShapeCheckBox.IsChecked = action.DisableBlendShapeReception;
             CustomNameTextBox.Text = action.Name;
             KeyUpCheckBox.IsChecked = action.IsKeyUp;
             KeyConfigs.AddRange(action.KeyConfigs);
@@ -156,7 +156,7 @@ namespace VirtualMotionCaptureControlPanel
             action.FaceNames = faceItems.Select(d => d.Key).ToList();
             action.FaceStrength = faceItems.Select(d => d.Value).ToList();
             action.StopBlink = AutoBlinkCheckBox.IsChecked.Value;
-            action.StopReceptionBlendShape = DisableBlendShape.IsChecked.Value;
+            action.DisableBlendShapeReception = DisableBlendShapeCheckBox.IsChecked.Value;
             action.IsKeyUp = KeyUpCheckBox.IsChecked.Value;
             action.LipSyncMaxLevel = (float)LipSyncMaxLevelSlider.Value;
 

--- a/ControlWindowWPF/ControlWindowWPF/Resources/Chinese.xaml
+++ b/ControlWindowWPF/ControlWindowWPF/Resources/Chinese.xaml
@@ -377,6 +377,7 @@
     <system:String x:Key="FaceControlKeyAddWindow_AddFacial">添加表情</system:String>
     <system:String x:Key="FaceControlKeyAddWindow_Add">添加</system:String>
     <system:String x:Key="FaceControlKeyAddWindow_DisableBlinking">取消自动眨眼</system:String>
+    <system:String x:Key="FaceControlKeyAddWindow_DisableBlendShape">Disabled BlendShape Reception</system:String>
     <system:String x:Key="FaceControlKeyAddWindow_LipSyncSuppression">抑制嘴型影响</system:String>
     <system:String x:Key="FaceControlKeyAddWindow_LipSyncMaxLevel">设置上限（0是不使用）</system:String>
     <system:String x:Key="FaceControlKeyAddWindow_Register">注册</system:String>

--- a/ControlWindowWPF/ControlWindowWPF/Resources/Chinese.xaml
+++ b/ControlWindowWPF/ControlWindowWPF/Resources/Chinese.xaml
@@ -377,7 +377,7 @@
     <system:String x:Key="FaceControlKeyAddWindow_AddFacial">添加表情</system:String>
     <system:String x:Key="FaceControlKeyAddWindow_Add">添加</system:String>
     <system:String x:Key="FaceControlKeyAddWindow_DisableBlinking">取消自动眨眼</system:String>
-    <system:String x:Key="FaceControlKeyAddWindow_DisableBlendShape">Disabled BlendShape Reception</system:String>
+    <system:String x:Key="FaceControlKeyAddWindow_DisableBlendShapeReception">Disable BlendShape Reception</system:String>
     <system:String x:Key="FaceControlKeyAddWindow_LipSyncSuppression">抑制嘴型影响</system:String>
     <system:String x:Key="FaceControlKeyAddWindow_LipSyncMaxLevel">设置上限（0是不使用）</system:String>
     <system:String x:Key="FaceControlKeyAddWindow_Register">注册</system:String>

--- a/ControlWindowWPF/ControlWindowWPF/Resources/English.xaml
+++ b/ControlWindowWPF/ControlWindowWPF/Resources/English.xaml
@@ -377,7 +377,7 @@
     <system:String x:Key="FaceControlKeyAddWindow_AddFacial">Add expression</system:String>
     <system:String x:Key="FaceControlKeyAddWindow_Add">Add</system:String>
     <system:String x:Key="FaceControlKeyAddWindow_DisableBlinking">Disable Auto blinking</system:String>
-    <system:String x:Key="FaceControlKeyAddWindow_DisableBlendShape">Disabled BlendShape Reception</system:String>
+    <system:String x:Key="FaceControlKeyAddWindow_DisableBlendShapeReception">Disable BlendShape Reception</system:String>
     <system:String x:Key="FaceControlKeyAddWindow_LipSyncSuppression">LipSync suppression</system:String>
     <system:String x:Key="FaceControlKeyAddWindow_LipSyncMaxLevel">Set the max value (0 is disable)</system:String>
     <system:String x:Key="FaceControlKeyAddWindow_Register">Register</system:String>

--- a/ControlWindowWPF/ControlWindowWPF/Resources/English.xaml
+++ b/ControlWindowWPF/ControlWindowWPF/Resources/English.xaml
@@ -377,6 +377,7 @@
     <system:String x:Key="FaceControlKeyAddWindow_AddFacial">Add expression</system:String>
     <system:String x:Key="FaceControlKeyAddWindow_Add">Add</system:String>
     <system:String x:Key="FaceControlKeyAddWindow_DisableBlinking">Disable Auto blinking</system:String>
+    <system:String x:Key="FaceControlKeyAddWindow_DisableBlendShape">Disabled BlendShape Reception</system:String>
     <system:String x:Key="FaceControlKeyAddWindow_LipSyncSuppression">LipSync suppression</system:String>
     <system:String x:Key="FaceControlKeyAddWindow_LipSyncMaxLevel">Set the max value (0 is disable)</system:String>
     <system:String x:Key="FaceControlKeyAddWindow_Register">Register</system:String>

--- a/ControlWindowWPF/ControlWindowWPF/Resources/Japanese.xaml
+++ b/ControlWindowWPF/ControlWindowWPF/Resources/Japanese.xaml
@@ -378,7 +378,7 @@
     <system:String x:Key="FaceControlKeyAddWindow_AddFacial">表情追加</system:String>
     <system:String x:Key="FaceControlKeyAddWindow_Add">追加</system:String>
     <system:String x:Key="FaceControlKeyAddWindow_DisableBlinking">自動まばたきを無効にする</system:String>
-    <system:String x:Key="FaceControlKeyAddWindow_DisableBlendShape">BlendShape受信を無効にする</system:String>
+    <system:String x:Key="FaceControlKeyAddWindow_DisableBlendShapeReception">BlendShape受信を無効にする</system:String>
     <system:String x:Key="FaceControlKeyAddWindow_LipSyncSuppression">リップシンク抑制(口の開きすぎを防ぐ)</system:String>
     <system:String x:Key="FaceControlKeyAddWindow_LipSyncMaxLevel">最大値を設定(0で無効)</system:String>
     <system:String x:Key="FaceControlKeyAddWindow_Register">登録</system:String>

--- a/ControlWindowWPF/ControlWindowWPF/Resources/Japanese.xaml
+++ b/ControlWindowWPF/ControlWindowWPF/Resources/Japanese.xaml
@@ -378,6 +378,7 @@
     <system:String x:Key="FaceControlKeyAddWindow_AddFacial">表情追加</system:String>
     <system:String x:Key="FaceControlKeyAddWindow_Add">追加</system:String>
     <system:String x:Key="FaceControlKeyAddWindow_DisableBlinking">自動まばたきを無効にする</system:String>
+    <system:String x:Key="FaceControlKeyAddWindow_DisableBlendShape">BlendShape受信を無効にする</system:String>
     <system:String x:Key="FaceControlKeyAddWindow_LipSyncSuppression">リップシンク抑制(口の開きすぎを防ぐ)</system:String>
     <system:String x:Key="FaceControlKeyAddWindow_LipSyncMaxLevel">最大値を設定(0で無効)</system:String>
     <system:String x:Key="FaceControlKeyAddWindow_Register">登録</system:String>

--- a/ControlWindowWPF/ControlWindowWPF/Resources/Korean.xaml
+++ b/ControlWindowWPF/ControlWindowWPF/Resources/Korean.xaml
@@ -378,6 +378,7 @@
     <system:String x:Key="FaceControlKeyAddWindow_AddFacial">표정추가</system:String>
     <system:String x:Key="FaceControlKeyAddWindow_Add">추가</system:String>
     <system:String x:Key="FaceControlKeyAddWindow_DisableBlinking">자동깜빡임을 무효로 함</system:String>
+    <system:String x:Key="FaceControlKeyAddWindow_DisableBlendShape">Disabled BlendShape Reception</system:String>
     <system:String x:Key="FaceControlKeyAddWindow_LipSyncSuppression">립싱크억제(입이너무크게열리는걸방지)</system:String>
     <system:String x:Key="FaceControlKeyAddWindow_LipSyncMaxLevel">최대치설정(0으로무효)</system:String>
     <system:String x:Key="FaceControlKeyAddWindow_Register">등록</system:String>

--- a/ControlWindowWPF/ControlWindowWPF/Resources/Korean.xaml
+++ b/ControlWindowWPF/ControlWindowWPF/Resources/Korean.xaml
@@ -378,7 +378,7 @@
     <system:String x:Key="FaceControlKeyAddWindow_AddFacial">표정추가</system:String>
     <system:String x:Key="FaceControlKeyAddWindow_Add">추가</system:String>
     <system:String x:Key="FaceControlKeyAddWindow_DisableBlinking">자동깜빡임을 무효로 함</system:String>
-    <system:String x:Key="FaceControlKeyAddWindow_DisableBlendShape">Disabled BlendShape Reception</system:String>
+    <system:String x:Key="FaceControlKeyAddWindow_DisableBlendShapeReception">Disable BlendShape Reception</system:String>
     <system:String x:Key="FaceControlKeyAddWindow_LipSyncSuppression">립싱크억제(입이너무크게열리는걸방지)</system:String>
     <system:String x:Key="FaceControlKeyAddWindow_LipSyncMaxLevel">최대치설정(0으로무효)</system:String>
     <system:String x:Key="FaceControlKeyAddWindow_Register">등록</system:String>

--- a/UnityMemoryMappedFile/PipeCommands.cs
+++ b/UnityMemoryMappedFile/PipeCommands.cs
@@ -1241,7 +1241,7 @@ namespace UnityMemoryMappedFile
         public Functions Function { get; set; }
         public bool StopBlink { get; set; }
         public bool SoftChange { get; set; }
-        public bool StopReceptionBlendShape { get; set; }
+        public bool DisableBlendShapeReception { get; set; }
 
         public float HandChangeTime { get; set; } = 0.1f;
         public float LipSyncMaxLevel { get; set; } = 1.0f;

--- a/UnityMemoryMappedFile/PipeCommands.cs
+++ b/UnityMemoryMappedFile/PipeCommands.cs
@@ -1241,6 +1241,7 @@ namespace UnityMemoryMappedFile
         public Functions Function { get; set; }
         public bool StopBlink { get; set; }
         public bool SoftChange { get; set; }
+        public bool StopReceptionBlendShape { get; set; }
 
         public float HandChangeTime { get; set; } = 0.1f;
         public float LipSyncMaxLevel { get; set; } = 1.0f;


### PR DESCRIPTION
表情コントロール設定に「BlendShape受信を無効にする」オプションを追加しました。
Onにすることで、対象表情の間 [”/VMC/Ext/Blend/Apply”] を無視します。