### PR TITLE
Unity画面に統合する設定を追加

### DIFF
--- a/Assets/Scripts/Setting/Settings.cs
+++ b/Assets/Scripts/Setting/Settings.cs
@@ -690,6 +690,8 @@ namespace VMC
         [OptionalField]
         public float PelvisOffsetAdjustZ;
 
+        [OptionalField]
+        public bool UnityChildWindowEnable;
 
         //初期値
         [OnDeserializing()]
@@ -862,6 +864,8 @@ namespace VMC
             OverrideBodyHeight = 1.7f;
             PelvisOffsetAdjustY = 0;
             PelvisOffsetAdjustZ = 0;
+
+            UnityChildWindowEnable = false;
         }
 
         /// <summary>

--- a/Assets/Scripts/Utils/NativeMethods.cs
+++ b/Assets/Scripts/Utils/NativeMethods.cs
@@ -38,6 +38,13 @@ namespace VMC
             public int height => bottom - top;
         }
 
+        public enum PROCESS_DPI_AWARENESS
+        {
+            Process_DPI_Unaware = 0,
+            Process_System_DPI_Aware = 1,
+            Process_Per_Monitor_DPI_Aware = 2
+        }
+
         [DllImport("user32.dll")]
         [return: MarshalAs(UnmanagedType.Bool)]
         public static extern bool GetCursorPos(out POINT lpPoint);
@@ -78,6 +85,11 @@ namespace VMC
         public static extern bool GetWindowRect(IntPtr hWnd, out RECT rect);
         [DllImport("user32.dll")]
         public static extern bool GetClientRect(IntPtr hWnd, out RECT lpRect);
+        [DllImport("Shcore.dll")]
+        public static extern int SetProcessDpiAwareness(PROCESS_DPI_AWARENESS awareness);
+        [DllImport("user32.dll")]
+        public static extern bool SetProcessDPIAware();
+
         public static readonly IntPtr HWND_TOPMOST = new IntPtr(-1);
         public static readonly IntPtr HWND_NOTOPMOST = new IntPtr(-2);
         public static readonly IntPtr HWND_TOP = new IntPtr(0);
@@ -122,6 +134,7 @@ namespace VMC
         public const int GWL_STYLE = -16;
         public const uint WS_POPUP = 0x80000000;
         public const uint WS_VISIBLE = 0x10000000;
+        public const uint WS_CLIPCHILDREN = 0x02000000;
         public const int GWL_EXSTYLE = -20;
         public const uint WS_EX_LAYERED = 0x00080000;
         public const uint WS_EX_TRANSPARENT = 0x00000020;

--- a/ControlWindowWPF/ControlWindowWPF/Resources/Chinese.xaml
+++ b/ControlWindowWPF/ControlWindowWPF/Resources/Chinese.xaml
@@ -282,6 +282,8 @@
     <system:String x:Key="SettingWindow_ReceiveBonesEnable">手骨接收</system:String>
     <system:String x:Key="SettingWindow_VMCMod">VMC Mod（不保证可用/不受支持）</system:String>
     <system:String x:Key="SettingWindow_VMCModSetting">已加载 MOD 列表</system:String>
+	<system:String x:Key="SettingWindow_Other">Other</system:String>
+	<system:String x:Key="SettingWindow_UnityChildWindow">Display Control Panel in Unity</system:String>
 
     <!-- CalibrationSettingWindow -->
     <system:String x:Key="CalibrationSettingWindow_BodyHeight">身高</system:String>

--- a/ControlWindowWPF/ControlWindowWPF/Resources/English.xaml
+++ b/ControlWindowWPF/ControlWindowWPF/Resources/English.xaml
@@ -282,6 +282,8 @@
     <system:String x:Key="SettingWindow_ReceiveBonesEnable">Receive hand bone</system:String>
     <system:String x:Key="SettingWindow_VMCMod">VMC Mod (No warranty/no support)</system:String>
     <system:String x:Key="SettingWindow_VMCModSetting">Loaded MOD List</system:String>
+	<system:String x:Key="SettingWindow_Other">Other</system:String>
+	<system:String x:Key="SettingWindow_UnityChildWindow">Display Control Panel in Unity</system:String>
 
     <!-- CalibrationSettingWindow -->
     <system:String x:Key="CalibrationSettingWindow_BodyHeight">Body Height</system:String>

--- a/ControlWindowWPF/ControlWindowWPF/Resources/Japanese.xaml
+++ b/ControlWindowWPF/ControlWindowWPF/Resources/Japanese.xaml
@@ -282,8 +282,10 @@
     <system:String x:Key="SettingWindow_ReceiveBonesEnable">手ボーン取得</system:String>
     <system:String x:Key="SettingWindow_VMCMod">VMC Mod (無保証/無サポート)</system:String>
     <system:String x:Key="SettingWindow_VMCModSetting">ロード済みModリスト</system:String>
+	<system:String x:Key="SettingWindow_Other">その他</system:String>
+	<system:String x:Key="SettingWindow_UnityChildWindow">コントロール画面をUnity内に表示する</system:String>
 
-    <!-- CalibrationSettingWindow -->
+	<!-- CalibrationSettingWindow -->
     <system:String x:Key="CalibrationSettingWindow_BodyHeight">身長設定</system:String>
     <system:String x:Key="CalibrationSettingWindow_OverrideBodyHeight">身長を上書き</system:String>
     <system:String x:Key="CalibrationSettingWindow_Height">身長 :</system:String>

--- a/ControlWindowWPF/ControlWindowWPF/Resources/Korean.xaml
+++ b/ControlWindowWPF/ControlWindowWPF/Resources/Korean.xaml
@@ -283,8 +283,11 @@
     <system:String x:Key="SettingWindow_ReceiveBonesEnable">손 본받는</system:String>
     <system:String x:Key="SettingWindow_VMCMod">VMC Mod (No warranty/no support)</system:String>
     <system:String x:Key="SettingWindow_VMCModSetting">Loaded MOD List</system:String>
+	<system:String x:Key="SettingWindow_Other">Other</system:String>
+	<system:String x:Key="SettingWindow_UnityChildWindow">Display Control Panel in Unity</system:String>
 
-    <!-- CalibrationSettingWindow -->
+
+	<!-- CalibrationSettingWindow -->
     <system:String x:Key="CalibrationSettingWindow_BodyHeight">Body Height</system:String>
     <system:String x:Key="CalibrationSettingWindow_OverrideBodyHeight">Override body height</system:String>
     <system:String x:Key="CalibrationSettingWindow_Height">Height :</system:String>

--- a/ControlWindowWPF/ControlWindowWPF/SettingWindow.xaml
+++ b/ControlWindowWPF/ControlWindowWPF/SettingWindow.xaml
@@ -269,7 +269,10 @@
                         <Button Content="{DynamicResource SettingWindow_VMCModSetting}" Name="ModSetting" Click="ModSetting_Click"/>
                     </DockPanel>
                 </GroupBox>
-                <GroupBox Header="{DynamicResource SettingWindow_Language}">
+				<GroupBox Header="{DynamicResource SettingWindow_Other}">
+					<CheckBox Content="{DynamicResource SettingWindow_UnityChildWindow}" Name="UnityChildWindowCheckBox" Checked="UnityChildWindowCheckBox_Changed" Unchecked="UnityChildWindowCheckBox_Changed" />
+				</GroupBox>
+				<GroupBox Header="{DynamicResource SettingWindow_Language}">
                     <ComboBox Name="LanguageComboBox" SelectedIndex="0" SelectionChanged="LanguageComboBox_SelectionChanged">
                         <system:String>Japanese</system:String>
                         <system:String>English</system:String>

--- a/ControlWindowWPF/ControlWindowWPF/SettingWindow.xaml.cs
+++ b/ControlWindowWPF/ControlWindowWPF/SettingWindow.xaml.cs
@@ -427,6 +427,17 @@ namespace VirtualMotionCaptureControlPanel
                 });
             });
 
+            await Globals.Client?.SendCommandWaitAsync(new PipeCommands.GetUnityChildWindowEnable { }, d =>
+            {
+                var data = (PipeCommands.SetUnityChildWindowEnable)d;
+                Dispatcher.Invoke(() =>
+                {
+                    isSetting = true;
+                    UnityChildWindowCheckBox.IsChecked = data.enable;
+                    isSetting = false;
+                });
+            });
+
             await Globals.Client?.SendCommandAsync(new PipeCommands.TrackerMovedRequest { doSend = true });
             await Globals.Client?.SendCommandAsync(new PipeCommands.StatusStringChangedRequest { doSend = true });
 
@@ -1149,6 +1160,15 @@ namespace VirtualMotionCaptureControlPanel
                 VMCProtocolReceiverEditButton.IsEnabled= false;
                 VMCProtocolReceiverRemoveButton.IsEnabled= false;
             }
+        }
+
+        private async void UnityChildWindowCheckBox_Changed(object sender, RoutedEventArgs e)
+        {
+            if (isSetting) return;
+            await Globals.Client?.SendCommandAsync(new PipeCommands.SetUnityChildWindowEnable
+            {
+                enable = UnityChildWindowCheckBox.IsChecked.Value
+            });
         }
     }
 }

--- a/ControlWindowWPF/ControlWindowWPF/VirtualMotionCaptureControlPanel.csproj
+++ b/ControlWindowWPF/ControlWindowWPF/VirtualMotionCaptureControlPanel.csproj
@@ -77,6 +77,9 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <Prefer32Bit>true</Prefer32Bit>
   </PropertyGroup>
+  <PropertyGroup>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Data" />
@@ -321,6 +324,7 @@
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
+    <None Include="app.manifest" />
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>

--- a/ControlWindowWPF/ControlWindowWPF/app.manifest
+++ b/ControlWindowWPF/ControlWindowWPF/app.manifest
@@ -1,0 +1,77 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <assemblyIdentity version="1.0.0.0" name="MyApplication.app"/>
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
+    <security>
+      <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">
+        <!-- UAC マニフェスト オプション
+             Windows のユーザー アカウント制御のレベルを変更するには、
+             requestedExecutionLevel ノードを以下のいずれかで置換します。
+
+        <requestedExecutionLevel  level="asInvoker" uiAccess="false" />
+        <requestedExecutionLevel  level="requireAdministrator" uiAccess="false" />
+        <requestedExecutionLevel  level="highestAvailable" uiAccess="false" />
+
+            requestedExecutionLevel 要素を指定すると、ファイルおよびレジストリの仮想化が無効にされます。
+            アプリケーションが下位互換性を保つためにこの仮想化を要求する場合、この要素を
+            削除します。
+        -->
+        <requestedExecutionLevel level="asInvoker" uiAccess="false" />
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <!-- このアプリケーションがテストされ、動作するよう設計された Windows バージョンの
+           一覧。適切な要素をコメント解除すると、最も互換性のある環境を Windows が
+           自動的に選択します。-->
+
+      <!-- Windows Vista -->
+      <!--<supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}" />-->
+
+      <!-- Windows 7 -->
+      <!--<supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}" />-->
+
+      <!-- Windows 8 -->
+      <!--<supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}" />-->
+
+      <!-- Windows 8.1 -->
+      <!--<supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}" />-->
+
+      <!-- Windows 10 -->
+      <!--<supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />-->
+
+    </application>
+  </compatibility>
+
+  <!-- アプリケーションが DPI 対応であり、Windows によってそれ以上の DPI には自動的に拡大縮小されないことを
+       示します。Windows Presentation Foundation (WPF) アプリケーションは自動的に DPI に対応し、オプトインする必要は
+       ありません。さらに、この設定にオプトインする .NET Framework 4.6 を対象とする Windows フォーム アプリケーションは、
+       app.config ファイルで 'EnableWindowsFormsHighDpiAutoResizing' 設定を 'true' に設定する必要があります。
+       
+       アプリケーションを長いパス対応にします。https://docs.microsoft.com/windows/win32/fileio/maximum-file-path-limitation をご覧ください -->
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true/PM</dpiAware>
+      <longPathAware xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">true</longPathAware>
+    </windowsSettings>
+  </application>
+
+  <!-- Windows のコモン コントロールとダイアログのテーマを有効にします (Windows XP 以降) -->
+  <!--
+  <dependency>
+    <dependentAssembly>
+      <assemblyIdentity
+          type="win32"
+          name="Microsoft.Windows.Common-Controls"
+          version="6.0.0.0"
+          processorArchitecture="*"
+          publicKeyToken="6595b64144ccf1df"
+          language="*"
+        />
+    </dependentAssembly>
+  </dependency>
+  -->
+
+</assembly>

--- a/UnityMemoryMappedFile/PipeCommands.cs
+++ b/UnityMemoryMappedFile/PipeCommands.cs
@@ -712,6 +712,17 @@ namespace UnityMemoryMappedFile
         {
             public bool DashboardOpened { get; set; }
         }
+        public class WindowInfo
+        {
+            public IntPtr Hwnd { get; set; }
+            public bool Child { get; set; }
+        }
+
+        public class GetUnityChildWindowEnable { }
+        public class SetUnityChildWindowEnable
+        {
+            public bool enable { get; set; }
+        }
 
     }
 


### PR DESCRIPTION
Unityにコントロールパネル画面を統合できるようになります。
オン・オフでき、その際に子ウィンドウ化・独立ウィンドウ化(従来)します。

+ WPF側機能の実装
+ Unity側の機能の実装
+ DPI Awarenessの変更
+ 各国語表記(ただし日本語以外は英語のみ)
+ セーブ・ロードの対応
+ 起動時・ロード時の反映対応

モニタ間のDPI変動によるサイズ変化は、ウィンドウ移動をトリガにして暫定的に対処しています。

![image](https://github.com/user-attachments/assets/04828318-e596-4262-b097-7e874c997ca9)
